### PR TITLE
Add custom attributes, web UI, subtask ID ladder, and CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: Test
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build
+        run: go build ./...
+
+      - name: Test
+        run: go test ./... -v -count=1

--- a/attribute.go
+++ b/attribute.go
@@ -1,0 +1,242 @@
+package gig
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+)
+
+// DefineAttr registers a new attribute key with its type.
+// This must be called before SetAttr can use that key.
+func (s *Store) DefineAttr(key string, attrType AttrType, description string) error {
+	if key == "" {
+		return fmt.Errorf("attribute key is required")
+	}
+	if !attrType.IsValid() {
+		return fmt.Errorf("invalid attribute type: %s", attrType)
+	}
+
+	now := timeNowUTC()
+	_, err := s.db.Exec(
+		`INSERT INTO attribute_definitions (key, attr_type, description, created_at)
+		 VALUES (?, ?, ?, ?)
+		 ON CONFLICT(key) DO UPDATE SET attr_type = ?, description = ?`,
+		key, string(attrType), description, now.Format(timeFormat),
+		string(attrType), description,
+	)
+	if err != nil {
+		return fmt.Errorf("define attribute: %w", err)
+	}
+	return nil
+}
+
+// UndefineAttr removes an attribute definition and all its values across all tasks.
+func (s *Store) UndefineAttr(key string) error {
+	// Delete values first (FK would block otherwise if cascade isn't enough).
+	if _, err := s.db.Exec("DELETE FROM custom_attributes WHERE key = ?", key); err != nil {
+		return fmt.Errorf("delete attribute values: %w", err)
+	}
+	result, err := s.db.Exec("DELETE FROM attribute_definitions WHERE key = ?", key)
+	if err != nil {
+		return fmt.Errorf("delete attribute definition: %w", err)
+	}
+	n, _ := result.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("attribute %q not defined", key)
+	}
+	return nil
+}
+
+// GetAttrDef retrieves a single attribute definition.
+func (s *Store) GetAttrDef(key string) (*AttrDefinition, error) {
+	var def AttrDefinition
+	var createdAt string
+	err := s.db.QueryRow(
+		"SELECT key, attr_type, description, created_at FROM attribute_definitions WHERE key = ?", key,
+	).Scan(&def.Key, &def.Type, &def.Description, &createdAt)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("attribute %q not defined", key)
+		}
+		return nil, fmt.Errorf("get attribute definition: %w", err)
+	}
+	if t := strToTime(createdAt); t != nil {
+		def.CreatedAt = *t
+	}
+	return &def, nil
+}
+
+// ListAttrDefs returns all defined attribute types.
+func (s *Store) ListAttrDefs() ([]*AttrDefinition, error) {
+	rows, err := s.db.Query(
+		"SELECT key, attr_type, description, created_at FROM attribute_definitions ORDER BY key",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list attribute definitions: %w", err)
+	}
+	defer rows.Close()
+
+	var defs []*AttrDefinition
+	for rows.Next() {
+		var def AttrDefinition
+		var createdAt string
+		if err := rows.Scan(&def.Key, &def.Type, &def.Description, &createdAt); err != nil {
+			return nil, fmt.Errorf("scan attribute definition: %w", err)
+		}
+		if t := strToTime(createdAt); t != nil {
+			def.CreatedAt = *t
+		}
+		defs = append(defs, &def)
+	}
+	return defs, rows.Err()
+}
+
+// SetAttr sets a custom attribute value on a task.
+// The attribute key must be defined first via DefineAttr.
+// The value is validated against the definition's type.
+func (s *Store) SetAttr(taskID, key, value string) error {
+	// Verify task exists.
+	if _, err := s.Get(taskID); err != nil {
+		return err
+	}
+
+	// Look up definition to validate type.
+	def, err := s.GetAttrDef(key)
+	if err != nil {
+		return err
+	}
+
+	// Validate value against type.
+	if err := validateAttrValue(def.Type, value); err != nil {
+		return fmt.Errorf("attribute %q: %w", key, err)
+	}
+
+	now := timeNowUTC()
+	nowStr := now.Format(timeFormat)
+
+	// Check if exists for event recording.
+	var oldValue string
+	var isUpdate bool
+	err = s.db.QueryRow(
+		"SELECT value FROM custom_attributes WHERE task_id = ? AND key = ?", taskID, key,
+	).Scan(&oldValue)
+	if err == nil {
+		isUpdate = true
+	}
+
+	_, err = s.db.Exec(
+		`INSERT INTO custom_attributes (task_id, key, value, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?)
+		 ON CONFLICT(task_id, key) DO UPDATE SET value = ?, updated_at = ?`,
+		taskID, key, value, nowStr, nowStr,
+		value, nowStr,
+	)
+	if err != nil {
+		return fmt.Errorf("set attribute: %w", err)
+	}
+
+	if isUpdate {
+		s.recordEvent(taskID, EventUpdated, "", "attr:"+key, oldValue, value)
+	} else {
+		s.recordEvent(taskID, EventUpdated, "", "attr:"+key, "", value)
+	}
+	return nil
+}
+
+// GetAttr retrieves a single custom attribute for a task.
+func (s *Store) GetAttr(taskID, key string) (*Attribute, error) {
+	var attr Attribute
+	var createdAt, updatedAt string
+	err := s.db.QueryRow(
+		`SELECT ca.task_id, ca.key, ca.value, ad.attr_type, ca.created_at, ca.updated_at
+		 FROM custom_attributes ca
+		 JOIN attribute_definitions ad ON ad.key = ca.key
+		 WHERE ca.task_id = ? AND ca.key = ?`, taskID, key,
+	).Scan(&attr.TaskID, &attr.Key, &attr.Value, &attr.Type, &createdAt, &updatedAt)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("attribute %q not set on task %s", key, taskID)
+		}
+		return nil, fmt.Errorf("get attribute: %w", err)
+	}
+	if t := strToTime(createdAt); t != nil {
+		attr.CreatedAt = *t
+	}
+	if t := strToTime(updatedAt); t != nil {
+		attr.UpdatedAt = *t
+	}
+	return &attr, nil
+}
+
+// Attrs returns all custom attributes for a task.
+func (s *Store) Attrs(taskID string) ([]*Attribute, error) {
+	rows, err := s.db.Query(
+		`SELECT ca.task_id, ca.key, ca.value, ad.attr_type, ca.created_at, ca.updated_at
+		 FROM custom_attributes ca
+		 JOIN attribute_definitions ad ON ad.key = ca.key
+		 WHERE ca.task_id = ?
+		 ORDER BY ca.key`, taskID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list attributes: %w", err)
+	}
+	defer rows.Close()
+
+	var attrs []*Attribute
+	for rows.Next() {
+		var attr Attribute
+		var createdAt, updatedAt string
+		if err := rows.Scan(&attr.TaskID, &attr.Key, &attr.Value, &attr.Type, &createdAt, &updatedAt); err != nil {
+			return nil, fmt.Errorf("scan attribute: %w", err)
+		}
+		if t := strToTime(createdAt); t != nil {
+			attr.CreatedAt = *t
+		}
+		if t := strToTime(updatedAt); t != nil {
+			attr.UpdatedAt = *t
+		}
+		attrs = append(attrs, &attr)
+	}
+	return attrs, rows.Err()
+}
+
+// DeleteAttr removes a custom attribute from a task.
+func (s *Store) DeleteAttr(taskID, key string) error {
+	// Get old value for event.
+	var oldValue string
+	err := s.db.QueryRow(
+		"SELECT value FROM custom_attributes WHERE task_id = ? AND key = ?", taskID, key,
+	).Scan(&oldValue)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return fmt.Errorf("attribute %q not set on task %s", key, taskID)
+		}
+		return fmt.Errorf("get attribute for delete: %w", err)
+	}
+
+	if _, err := s.db.Exec(
+		"DELETE FROM custom_attributes WHERE task_id = ? AND key = ?", taskID, key,
+	); err != nil {
+		return fmt.Errorf("delete attribute: %w", err)
+	}
+
+	s.recordEvent(taskID, EventUpdated, "", "attr:"+key, oldValue, "")
+	return nil
+}
+
+// validateAttrValue checks that a value matches the expected attribute type.
+func validateAttrValue(attrType AttrType, value string) error {
+	switch attrType {
+	case AttrBoolean:
+		if value != "true" && value != "false" {
+			return fmt.Errorf("boolean attribute must be \"true\" or \"false\", got %q", value)
+		}
+	case AttrObject:
+		if !json.Valid([]byte(value)) {
+			return fmt.Errorf("object attribute must be valid JSON")
+		}
+	case AttrString:
+		// Any value is valid.
+	}
+	return nil
+}

--- a/attribute_test.go
+++ b/attribute_test.go
@@ -1,0 +1,284 @@
+package gig
+
+import (
+	"testing"
+)
+
+func TestDefineAndListAttrDefs(t *testing.T) {
+	store, _ := tempDB(t)
+
+	if err := store.DefineAttr("worktree", AttrString, "Git worktree path"); err != nil {
+		t.Fatalf("define: %v", err)
+	}
+	if err := store.DefineAttr("tested", AttrBoolean, "Tests passed"); err != nil {
+		t.Fatalf("define: %v", err)
+	}
+	if err := store.DefineAttr("config", AttrObject, "Agent config JSON"); err != nil {
+		t.Fatalf("define: %v", err)
+	}
+
+	defs, err := store.ListAttrDefs()
+	if err != nil {
+		t.Fatalf("list defs: %v", err)
+	}
+	if len(defs) != 3 {
+		t.Fatalf("expected 3 defs, got %d", len(defs))
+	}
+	// Sorted by key: config, tested, worktree
+	if defs[0].Key != "config" || defs[0].Type != AttrObject {
+		t.Errorf("defs[0] = %q/%s, want config/object", defs[0].Key, defs[0].Type)
+	}
+}
+
+func TestDefineAttrInvalidType(t *testing.T) {
+	store, _ := tempDB(t)
+	err := store.DefineAttr("foo", AttrType("invalid"), "")
+	if err == nil {
+		t.Error("expected error for invalid type")
+	}
+}
+
+func TestDefineAttrUpsert(t *testing.T) {
+	store, _ := tempDB(t)
+	store.DefineAttr("phase", AttrString, "old desc")
+	store.DefineAttr("phase", AttrString, "new desc")
+
+	def, err := store.GetAttrDef("phase")
+	if err != nil {
+		t.Fatalf("get def: %v", err)
+	}
+	if def.Description != "new desc" {
+		t.Errorf("description = %q, want 'new desc'", def.Description)
+	}
+}
+
+func TestSetAndGetStringAttr(t *testing.T) {
+	store, _ := tempDB(t)
+	store.DefineAttr("worktree", AttrString, "")
+	task, _ := store.Create(CreateParams{Title: "Test"})
+
+	if err := store.SetAttr(task.ID, "worktree", "/tmp/wt-1"); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+
+	attr, err := store.GetAttr(task.ID, "worktree")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if attr.Value != "/tmp/wt-1" {
+		t.Errorf("value = %q, want '/tmp/wt-1'", attr.Value)
+	}
+	if attr.Type != AttrString {
+		t.Errorf("type = %q, want 'string'", attr.Type)
+	}
+	if attr.StringValue() != "/tmp/wt-1" {
+		t.Errorf("StringValue() = %q", attr.StringValue())
+	}
+}
+
+func TestSetAndGetBoolAttr(t *testing.T) {
+	store, _ := tempDB(t)
+	store.DefineAttr("tested", AttrBoolean, "")
+	task, _ := store.Create(CreateParams{Title: "Test"})
+
+	if err := store.SetAttr(task.ID, "tested", "true"); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+
+	attr, err := store.GetAttr(task.ID, "tested")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !attr.BoolValue() {
+		t.Error("BoolValue() should be true")
+	}
+
+	// Set to false
+	store.SetAttr(task.ID, "tested", "false")
+	attr, _ = store.GetAttr(task.ID, "tested")
+	if attr.BoolValue() {
+		t.Error("BoolValue() should be false after update")
+	}
+}
+
+func TestSetBoolAttrRejectsInvalid(t *testing.T) {
+	store, _ := tempDB(t)
+	store.DefineAttr("tested", AttrBoolean, "")
+	task, _ := store.Create(CreateParams{Title: "Test"})
+
+	err := store.SetAttr(task.ID, "tested", "yes")
+	if err == nil {
+		t.Error("expected error for invalid boolean value")
+	}
+}
+
+func TestSetAndGetObjectAttr(t *testing.T) {
+	store, _ := tempDB(t)
+	store.DefineAttr("config", AttrObject, "")
+	task, _ := store.Create(CreateParams{Title: "Test"})
+
+	jsonVal := `{"model":"opus","temp":0.7}`
+	if err := store.SetAttr(task.ID, "config", jsonVal); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+
+	attr, err := store.GetAttr(task.ID, "config")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if attr.Value != jsonVal {
+		t.Errorf("value = %q, want %q", attr.Value, jsonVal)
+	}
+
+	obj, err := attr.ObjectValue()
+	if err != nil {
+		t.Fatalf("ObjectValue: %v", err)
+	}
+	if obj["model"] != "opus" {
+		t.Errorf("obj[model] = %v, want 'opus'", obj["model"])
+	}
+}
+
+func TestSetObjectAttrRejectsInvalidJSON(t *testing.T) {
+	store, _ := tempDB(t)
+	store.DefineAttr("config", AttrObject, "")
+	task, _ := store.Create(CreateParams{Title: "Test"})
+
+	err := store.SetAttr(task.ID, "config", "not json")
+	if err == nil {
+		t.Error("expected error for invalid JSON")
+	}
+}
+
+func TestSetAttrRejectsUndefinedKey(t *testing.T) {
+	store, _ := tempDB(t)
+	task, _ := store.Create(CreateParams{Title: "Test"})
+
+	err := store.SetAttr(task.ID, "undefined_key", "value")
+	if err == nil {
+		t.Error("expected error for undefined attribute key")
+	}
+}
+
+func TestSetAttrUpsert(t *testing.T) {
+	store, _ := tempDB(t)
+	store.DefineAttr("branch", AttrString, "")
+	task, _ := store.Create(CreateParams{Title: "Test"})
+
+	store.SetAttr(task.ID, "branch", "main")
+	store.SetAttr(task.ID, "branch", "feature/x")
+
+	attr, _ := store.GetAttr(task.ID, "branch")
+	if attr.Value != "feature/x" {
+		t.Errorf("value = %q, want 'feature/x'", attr.Value)
+	}
+}
+
+func TestListAttrs(t *testing.T) {
+	store, _ := tempDB(t)
+	store.DefineAttr("worktree", AttrString, "")
+	store.DefineAttr("tested", AttrBoolean, "")
+	task, _ := store.Create(CreateParams{Title: "Test"})
+
+	store.SetAttr(task.ID, "worktree", "/tmp/wt")
+	store.SetAttr(task.ID, "tested", "true")
+
+	attrs, err := store.Attrs(task.ID)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(attrs) != 2 {
+		t.Fatalf("expected 2 attrs, got %d", len(attrs))
+	}
+}
+
+func TestDeleteAttr(t *testing.T) {
+	store, _ := tempDB(t)
+	store.DefineAttr("phase", AttrString, "")
+	task, _ := store.Create(CreateParams{Title: "Test"})
+
+	store.SetAttr(task.ID, "phase", "research")
+
+	if err := store.DeleteAttr(task.ID, "phase"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	_, err := store.GetAttr(task.ID, "phase")
+	if err == nil {
+		t.Error("expected error after delete")
+	}
+}
+
+func TestDeleteAttrNotSet(t *testing.T) {
+	store, _ := tempDB(t)
+	task, _ := store.Create(CreateParams{Title: "Test"})
+
+	err := store.DeleteAttr(task.ID, "nonexistent")
+	if err == nil {
+		t.Error("expected error for deleting non-existent attr")
+	}
+}
+
+func TestUndefineAttrCascades(t *testing.T) {
+	store, _ := tempDB(t)
+	store.DefineAttr("phase", AttrString, "")
+	t1, _ := store.Create(CreateParams{Title: "T1"})
+	t2, _ := store.Create(CreateParams{Title: "T2"})
+
+	store.SetAttr(t1.ID, "phase", "research")
+	store.SetAttr(t2.ID, "phase", "code")
+
+	if err := store.UndefineAttr("phase"); err != nil {
+		t.Fatalf("undefine: %v", err)
+	}
+
+	// All values should be gone.
+	_, err := store.GetAttr(t1.ID, "phase")
+	if err == nil {
+		t.Error("expected error — value should be deleted")
+	}
+	_, err = store.GetAttr(t2.ID, "phase")
+	if err == nil {
+		t.Error("expected error — value should be deleted")
+	}
+}
+
+func TestListFilterByAttr(t *testing.T) {
+	store, _ := tempDB(t)
+	store.DefineAttr("phase", AttrString, "")
+	store.DefineAttr("tested", AttrBoolean, "")
+
+	t1, _ := store.Create(CreateParams{Title: "Research task"})
+	t2, _ := store.Create(CreateParams{Title: "Code task"})
+	t3, _ := store.Create(CreateParams{Title: "Done task"})
+
+	store.SetAttr(t1.ID, "phase", "research")
+	store.SetAttr(t2.ID, "phase", "code")
+	store.SetAttr(t3.ID, "phase", "code")
+	store.SetAttr(t3.ID, "tested", "true")
+
+	// Filter by phase=code
+	results, err := store.List(ListParams{
+		AttrFilter: map[string]string{"phase": "code"},
+	})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(results) != 2 {
+		t.Errorf("expected 2 tasks with phase=code, got %d", len(results))
+	}
+
+	// Filter by phase=code AND tested=true
+	results, err = store.List(ListParams{
+		AttrFilter: map[string]string{"phase": "code", "tested": "true"},
+	})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("expected 1 task with phase=code AND tested=true, got %d", len(results))
+	}
+	if len(results) > 0 && results[0].ID != t3.ID {
+		t.Errorf("expected task %s, got %s", t3.ID, results[0].ID)
+	}
+}

--- a/cmd/gig/attr_cmds.go
+++ b/cmd/gig/attr_cmds.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/neerajg/gig"
+	"github.com/spf13/cobra"
+)
+
+func attrCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "attr",
+		Short: "Manage custom attributes",
+		Long:  "Define attribute types and set/get typed key-value pairs on tasks.",
+	}
+
+	cmd.AddCommand(
+		attrDefineCmd(),
+		attrUndefineCmd(),
+		attrTypesCmd(),
+		attrSetCmd(),
+		attrGetCmd(),
+		attrListCmd(),
+		attrDeleteCmd(),
+	)
+
+	return cmd
+}
+
+func attrDefineCmd() *cobra.Command {
+	var attrType string
+	var description string
+
+	cmd := &cobra.Command{
+		Use:   "define <key>",
+		Short: "Define a new attribute type",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			key := args[0]
+			t := gig.AttrType(attrType)
+			if !t.IsValid() {
+				return fmt.Errorf("invalid type %q, must be: string, boolean, object", attrType)
+			}
+			if err := store.DefineAttr(key, t, description); err != nil {
+				return err
+			}
+			if !quietOutput {
+				fmt.Printf("Defined attribute %q (type: %s)\n", key, attrType)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&attrType, "type", "string", "Attribute type: string, boolean, object")
+	cmd.Flags().StringVar(&description, "description", "", "Description of the attribute")
+
+	return cmd
+}
+
+func attrUndefineCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "undefine <key>",
+		Short: "Remove an attribute definition and all its values",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := store.UndefineAttr(args[0]); err != nil {
+				return err
+			}
+			if !quietOutput {
+				fmt.Printf("Removed attribute %q and all its values\n", args[0])
+			}
+			return nil
+		},
+	}
+}
+
+func attrTypesCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "types",
+		Short: "List all defined attribute types",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			defs, err := store.ListAttrDefs()
+			if err != nil {
+				return err
+			}
+
+			if jsonOutput {
+				enc := json.NewEncoder(os.Stdout)
+				enc.SetIndent("", "  ")
+				return enc.Encode(defs)
+			}
+
+			if len(defs) == 0 {
+				fmt.Println("No attribute types defined. Use 'gig attr define <key> --type <type>' to create one.")
+				return nil
+			}
+
+			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+			fmt.Fprintf(w, "KEY\tTYPE\tDESCRIPTION\n")
+			for _, d := range defs {
+				fmt.Fprintf(w, "%s\t%s\t%s\n", d.Key, d.Type, d.Description)
+			}
+			return w.Flush()
+		},
+	}
+}
+
+func attrSetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "set <task-id> <key> <value>",
+		Short: "Set a custom attribute on a task",
+		Args:  cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			taskID, key, value := args[0], args[1], args[2]
+			if err := store.SetAttr(taskID, key, value); err != nil {
+				return err
+			}
+			if !quietOutput {
+				fmt.Printf("%s.%s = %s\n", taskID, key, value)
+			}
+			return nil
+		},
+	}
+}
+
+func attrGetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <task-id> <key>",
+		Short: "Get a custom attribute value",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			attr, err := store.GetAttr(args[0], args[1])
+			if err != nil {
+				return err
+			}
+
+			if jsonOutput {
+				enc := json.NewEncoder(os.Stdout)
+				enc.SetIndent("", "  ")
+				return enc.Encode(attr)
+			}
+
+			fmt.Printf("%s (%s)\n", attr.Value, attr.Type)
+			return nil
+		},
+	}
+}
+
+func attrListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list <task-id>",
+		Short: "List all custom attributes on a task",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			attrs, err := store.Attrs(args[0])
+			if err != nil {
+				return err
+			}
+
+			if jsonOutput {
+				enc := json.NewEncoder(os.Stdout)
+				enc.SetIndent("", "  ")
+				return enc.Encode(attrs)
+			}
+
+			if len(attrs) == 0 {
+				fmt.Println("No attributes set.")
+				return nil
+			}
+
+			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+			fmt.Fprintf(w, "KEY\tVALUE\tTYPE\n")
+			for _, a := range attrs {
+				fmt.Fprintf(w, "%s\t%s\t%s\n", a.Key, a.Value, a.Type)
+			}
+			return w.Flush()
+		},
+	}
+}
+
+func attrDeleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete <task-id> <key>",
+		Short: "Remove a custom attribute from a task",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := store.DeleteAttr(args[0], args[1]); err != nil {
+				return err
+			}
+			if !quietOutput {
+				fmt.Printf("Deleted %s.%s\n", args[0], args[1])
+			}
+			return nil
+		},
+	}
+}

--- a/cmd/gig/ui_cmd.go
+++ b/cmd/gig/ui_cmd.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/neerajg/gig/ui"
+	"github.com/spf13/cobra"
+)
+
+func uiCmd() *cobra.Command {
+	var port int
+
+	cmd := &cobra.Command{
+		Use:   "ui",
+		Short: "Start the web-based kanban board UI",
+		Long:  "Launches a local web server with a drag-and-drop kanban board for managing tasks.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			server := ui.New(store)
+			addr := fmt.Sprintf(":%d", port)
+			fmt.Printf("gig ui running at http://localhost:%d\n", port)
+			return server.ListenAndServe(addr)
+		},
+	}
+
+	cmd.Flags().IntVarP(&port, "port", "p", 9741, "Port to listen on")
+
+	return cmd
+}

--- a/examples/gig-controller/handlers.go
+++ b/examples/gig-controller/handlers.go
@@ -1,0 +1,331 @@
+package main
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/neerajg/gig"
+)
+
+// Column represents a kanban column for template rendering.
+type Column struct {
+	Status gig.Status
+	Tasks  []*gig.Task
+}
+
+// BoardData is the template data for the board view.
+type BoardData struct {
+	Columns    []Column
+	ReadyCount int
+	TotalCount int
+	View       string // "top" or "all"
+}
+
+// DetailData is the template data for the task detail view.
+type DetailData struct {
+	Task            *gig.Task
+	Comments        []*gig.Comment
+	DepsOn          []*DepInfo
+	Blocks          []*DepInfo
+	Children        []*gig.Task
+	ChildrenColumns []Column // children grouped by status for mini kanban
+	Events          []*gig.Event
+	AllTasks        []*gig.Task // for parent selector in forms
+}
+
+// DepInfo pairs a dependency with its task info.
+type DepInfo struct {
+	Task *gig.Task
+	Dep  *gig.Dependency
+}
+
+func handleBoard(w http.ResponseWriter, r *http.Request) {
+	statuses := []gig.Status{
+		gig.StatusOpen, gig.StatusInProgress, gig.StatusBlocked,
+		gig.StatusDeferred, gig.StatusClosed,
+	}
+
+	// Filter: "top" (default) shows only root tasks, "all" shows everything.
+	view := r.URL.Query().Get("view")
+	if view == "" {
+		view = "top"
+	}
+	topOnly := view == "top"
+
+	var columns []Column
+	total := 0
+	for _, s := range statuses {
+		status := s
+		tasks, _ := store.List(gig.ListParams{Status: &status})
+		if topOnly {
+			var filtered []*gig.Task
+			for _, t := range tasks {
+				if t.ParentID == "" {
+					filtered = append(filtered, t)
+				}
+			}
+			tasks = filtered
+		}
+		columns = append(columns, Column{Status: s, Tasks: tasks})
+		total += len(tasks)
+	}
+
+	ready, _ := store.Ready()
+
+	data := BoardData{
+		Columns:    columns,
+		ReadyCount: len(ready),
+		TotalCount: total,
+		View:       view,
+	}
+
+	w.Header().Set("Content-Type", "text/html")
+	tmpl.ExecuteTemplate(w, "board.html", data)
+}
+
+func handleDetail(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	task, err := store.Get(id)
+	if err != nil {
+		http.Error(w, "Task not found", 404)
+		return
+	}
+
+	comments, _ := store.ListComments(id)
+	deps, _ := store.ListDependencies(id)
+	dependents, _ := store.ListDependents(id)
+	children, _ := store.Children(id)
+	events, _ := store.Events(id)
+
+	var depsOn []*DepInfo
+	for _, d := range deps {
+		t, err := store.Get(d.ToID)
+		if err == nil {
+			depsOn = append(depsOn, &DepInfo{Task: t, Dep: d})
+		}
+	}
+
+	var blocks []*DepInfo
+	for _, d := range dependents {
+		t, err := store.Get(d.FromID)
+		if err == nil {
+			blocks = append(blocks, &DepInfo{Task: t, Dep: d})
+		}
+	}
+
+	// Group children by status for mini kanban.
+	var childColumns []Column
+	if len(children) > 0 {
+		statusOrder := []gig.Status{
+			gig.StatusOpen, gig.StatusInProgress, gig.StatusBlocked,
+			gig.StatusDeferred, gig.StatusClosed,
+		}
+		grouped := map[gig.Status][]*gig.Task{}
+		for _, c := range children {
+			grouped[c.Status] = append(grouped[c.Status], c)
+		}
+		for _, s := range statusOrder {
+			if tasks, ok := grouped[s]; ok {
+				childColumns = append(childColumns, Column{Status: s, Tasks: tasks})
+			}
+		}
+	}
+
+	data := DetailData{
+		Task:            task,
+		Comments:        comments,
+		DepsOn:          depsOn,
+		Blocks:          blocks,
+		Children:        children,
+		ChildrenColumns: childColumns,
+		Events:          events,
+	}
+
+	w.Header().Set("Content-Type", "text/html")
+	tmpl.ExecuteTemplate(w, "detail.html", data)
+}
+
+func handleCreateForm(w http.ResponseWriter, r *http.Request) {
+	allTasks, _ := store.List(gig.ListParams{})
+	data := DetailData{AllTasks: allTasks}
+	w.Header().Set("Content-Type", "text/html")
+	tmpl.ExecuteTemplate(w, "create.html", data)
+}
+
+func handleCreate(w http.ResponseWriter, r *http.Request) {
+	r.ParseForm()
+
+	priority := gig.P2
+	switch r.FormValue("priority") {
+	case "0":
+		priority = gig.P0
+	case "1":
+		priority = gig.P1
+	case "3":
+		priority = gig.P3
+	case "4":
+		priority = gig.P4
+	}
+
+	var labels []string
+	if l := r.FormValue("labels"); l != "" {
+		labels = strings.Split(l, ",")
+		for i := range labels {
+			labels[i] = strings.TrimSpace(labels[i])
+		}
+	}
+
+	_, err := store.Create(gig.CreateParams{
+		Title:       r.FormValue("title"),
+		Description: r.FormValue("description"),
+		Type:        gig.TaskType(r.FormValue("type")),
+		Priority:    priority,
+		ParentID:    r.FormValue("parent"),
+		Assignee:    r.FormValue("assignee"),
+		Labels:      labels,
+		Notes:       r.FormValue("notes"),
+		CreatedBy:   "web",
+	})
+	if err != nil {
+		http.Error(w, err.Error(), 400)
+		return
+	}
+
+	http.Redirect(w, r, "/", http.StatusSeeOther)
+}
+
+func handleStatusChange(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	r.ParseForm()
+	newStatus := gig.Status(r.FormValue("status"))
+
+	if err := store.UpdateStatus(id, newStatus, "web"); err != nil {
+		http.Error(w, err.Error(), 400)
+		return
+	}
+
+	if r.Header.Get("HX-Request") == "true" {
+		w.Header().Set("HX-Redirect", "/task/"+id)
+		w.WriteHeader(200)
+		return
+	}
+	http.Redirect(w, r, "/task/"+id, http.StatusSeeOther)
+}
+
+func handleAddComment(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	r.ParseForm()
+
+	author := r.FormValue("author")
+	if author == "" {
+		author = "web"
+	}
+
+	_, err := store.AddComment(id, author, r.FormValue("content"))
+	if err != nil {
+		http.Error(w, err.Error(), 400)
+		return
+	}
+
+	// If HTMX request, re-render the comments section.
+	if r.Header.Get("HX-Request") == "true" {
+		comments, _ := store.ListComments(id)
+		tmpl.ExecuteTemplate(w, "comments.html", comments)
+		return
+	}
+	http.Redirect(w, r, "/task/"+id, http.StatusSeeOther)
+}
+
+func handleClose(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	r.ParseForm()
+	reason := r.FormValue("reason")
+
+	if err := store.CloseTask(id, reason, "web"); err != nil {
+		http.Error(w, err.Error(), 400)
+		return
+	}
+
+	if r.Header.Get("HX-Request") == "true" {
+		w.Header().Set("HX-Redirect", "/task/"+id)
+		w.WriteHeader(200)
+		return
+	}
+	http.Redirect(w, r, "/task/"+id, http.StatusSeeOther)
+}
+
+func handleReopen(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+
+	if err := store.Reopen(id, "web"); err != nil {
+		http.Error(w, err.Error(), 400)
+		return
+	}
+
+	if r.Header.Get("HX-Request") == "true" {
+		w.Header().Set("HX-Redirect", "/task/"+id)
+		w.WriteHeader(200)
+		return
+	}
+	http.Redirect(w, r, "/task/"+id, http.StatusSeeOther)
+}
+
+func handleEditForm(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	task, err := store.Get(id)
+	if err != nil {
+		http.Error(w, "Task not found", 404)
+		return
+	}
+
+	allTasks, _ := store.List(gig.ListParams{})
+	data := DetailData{Task: task, AllTasks: allTasks}
+	w.Header().Set("Content-Type", "text/html")
+	tmpl.ExecuteTemplate(w, "edit.html", data)
+}
+
+func handleEdit(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	r.ParseForm()
+
+	title := r.FormValue("title")
+	desc := r.FormValue("description")
+	assignee := r.FormValue("assignee")
+	notes := r.FormValue("notes")
+
+	priority := gig.P2
+	switch r.FormValue("priority") {
+	case "0":
+		priority = gig.P0
+	case "1":
+		priority = gig.P1
+	case "3":
+		priority = gig.P3
+	case "4":
+		priority = gig.P4
+	}
+
+	var labels *[]string
+	if l := r.FormValue("labels"); l != "" {
+		parts := strings.Split(l, ",")
+		for i := range parts {
+			parts[i] = strings.TrimSpace(parts[i])
+		}
+		labels = &parts
+	}
+
+	_, err := store.Update(id, gig.UpdateParams{
+		Title:       &title,
+		Description: &desc,
+		Priority:    &priority,
+		Assignee:    &assignee,
+		Notes:       &notes,
+		Labels:      labels,
+	}, "web")
+	if err != nil {
+		http.Error(w, err.Error(), 400)
+		return
+	}
+
+	http.Redirect(w, r, "/task/"+id, http.StatusSeeOther)
+}

--- a/examples/gig-controller/main.go
+++ b/examples/gig-controller/main.go
@@ -1,0 +1,167 @@
+// gig-controller is a web-based kanban board that demonstrates the gig SDK.
+// Run: GIG_HOME=/tmp/gig-demo go run .
+// Open: http://localhost:9741
+package main
+
+import (
+	"embed"
+	"fmt"
+	"html/template"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/neerajg/gig"
+)
+
+//go:embed templates/*
+var templateFS embed.FS
+
+var (
+	store *gig.Store
+	tmpl  *template.Template
+)
+
+func main() {
+	// Initialize gig store.
+	cfg, err := gig.LoadConfig("")
+	if err != nil {
+		log.Fatalf("load config: %v", err)
+	}
+
+	// Auto-init if no DB exists.
+	if _, err := os.Stat(cfg.DBPath); os.IsNotExist(err) {
+		if err := gig.SaveConfig("", cfg); err != nil {
+			log.Fatalf("save config: %v", err)
+		}
+	}
+
+	store, err = gig.Open(cfg.DBPath, gig.WithPrefix(cfg.Prefix), gig.WithHashLength(cfg.HashLen))
+	if err != nil {
+		log.Fatalf("open store: %v", err)
+	}
+	defer store.Close()
+
+	// Seed demo data if DB is empty.
+	seedDemoData()
+
+	// Parse templates with helper functions.
+	funcMap := template.FuncMap{
+		"statusIcon": func(s gig.Status) string {
+			switch s {
+			case gig.StatusOpen:
+				return "○"
+			case gig.StatusInProgress:
+				return "◉"
+			case gig.StatusBlocked:
+				return "⊘"
+			case gig.StatusDeferred:
+				return "◌"
+			case gig.StatusClosed:
+				return "✓"
+			default:
+				return "?"
+			}
+		},
+		"priorityClass": func(p gig.Priority) string {
+			switch p {
+			case gig.P0:
+				return "priority-critical"
+			case gig.P1:
+				return "priority-high"
+			case gig.P2:
+				return "priority-medium"
+			case gig.P3:
+				return "priority-low"
+			case gig.P4:
+				return "priority-backlog"
+			default:
+				return ""
+			}
+		},
+		"priorityLabel": func(p gig.Priority) string {
+			switch p {
+			case gig.P0:
+				return "P0"
+			case gig.P1:
+				return "P1"
+			case gig.P2:
+				return "P2"
+			case gig.P3:
+				return "P3"
+			case gig.P4:
+				return "P4"
+			default:
+				return "?"
+			}
+		},
+		"statusLabel": func(s gig.Status) string {
+			switch s {
+			case gig.StatusOpen:
+				return "Open"
+			case gig.StatusInProgress:
+				return "In Progress"
+			case gig.StatusBlocked:
+				return "Blocked"
+			case gig.StatusDeferred:
+				return "Deferred"
+			case gig.StatusClosed:
+				return "Closed"
+			default:
+				return string(s)
+			}
+		},
+		"columnColor": func(s gig.Status) string {
+			switch s {
+			case gig.StatusOpen:
+				return "#6b7280"
+			case gig.StatusInProgress:
+				return "#3b82f6"
+			case gig.StatusBlocked:
+				return "#ef4444"
+			case gig.StatusDeferred:
+				return "#f59e0b"
+			case gig.StatusClosed:
+				return "#22c55e"
+			default:
+				return "#6b7280"
+			}
+		},
+	}
+
+	tmpl, err = template.New("").Funcs(funcMap).ParseFS(templateFS, "templates/*.html", "templates/partials/*.html")
+	if err != nil {
+		log.Fatalf("parse templates: %v", err)
+	}
+
+	// Routes.
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /", handleBoard)
+	mux.HandleFunc("GET /task/{id}", handleDetail)
+	mux.HandleFunc("GET /new", handleCreateForm)
+	mux.HandleFunc("POST /new", handleCreate)
+	mux.HandleFunc("POST /task/{id}/status", handleStatusChange)
+	mux.HandleFunc("POST /task/{id}/comment", handleAddComment)
+	mux.HandleFunc("POST /task/{id}/close", handleClose)
+	mux.HandleFunc("POST /task/{id}/reopen", handleReopen)
+	mux.HandleFunc("GET /task/{id}/edit", handleEditForm)
+	mux.HandleFunc("POST /task/{id}/edit", handleEdit)
+	mux.HandleFunc("GET /static/style.css", handleCSS)
+
+	port := "9741"
+	if p := os.Getenv("PORT"); p != "" {
+		port = p
+	}
+	fmt.Printf("gig-controller running at http://localhost:%s\n", port)
+	log.Fatal(http.ListenAndServe(":"+port, mux))
+}
+
+func handleCSS(w http.ResponseWriter, r *http.Request) {
+	data, err := templateFS.ReadFile("templates/static/style.css")
+	if err != nil {
+		http.Error(w, "CSS not found", 404)
+		return
+	}
+	w.Header().Set("Content-Type", "text/css")
+	w.Write(data)
+}

--- a/examples/gig-controller/seed.go
+++ b/examples/gig-controller/seed.go
@@ -1,0 +1,234 @@
+package main
+
+import (
+	"log"
+
+	"github.com/neerajg/gig"
+)
+
+// seedDemoData populates the store with sample tasks if the DB is empty.
+func seedDemoData() {
+	all, _ := store.List(gig.ListParams{Limit: 1})
+	if len(all) > 0 {
+		return // already has data
+	}
+
+	log.Println("Seeding demo data...")
+
+	// ── Epic 1: Platform Launch ──────────────────────────────────────
+	launch, _ := store.Create(gig.CreateParams{
+		Title:       "Platform Launch",
+		Description: "Ship v1.0 of the platform with core features, infrastructure, and documentation.",
+		Type:        gig.TypeEpic,
+		Priority:    gig.P0,
+		Assignee:    "neeraj",
+		Labels:      []string{"launch", "q1"},
+		CreatedBy:   "seed",
+	})
+
+	// Subtasks: launch.1, launch.2, launch.3, launch.4
+	auth, _ := store.Create(gig.CreateParams{
+		Title:       "Implement auth system",
+		Description: "OAuth2 + JWT token flow with refresh tokens.",
+		Type:        gig.TypeFeature,
+		Priority:    gig.P0,
+		ParentID:    launch.ID,
+		Assignee:    "neeraj",
+		Labels:      []string{"backend", "security"},
+		CreatedBy:   "seed",
+	})
+	store.UpdateStatus(auth.ID, gig.StatusInProgress, "seed")
+
+	api, _ := store.Create(gig.CreateParams{
+		Title:       "Build REST API",
+		Description: "CRUD endpoints for all core resources.",
+		Type:        gig.TypeFeature,
+		Priority:    gig.P1,
+		ParentID:    launch.ID,
+		Assignee:    "jeff",
+		Labels:      []string{"backend", "api"},
+		CreatedBy:   "seed",
+	})
+	store.UpdateStatus(api.ID, gig.StatusInProgress, "seed")
+
+	ui, _ := store.Create(gig.CreateParams{
+		Title:       "Design dashboard UI",
+		Description: "Main dashboard with analytics widgets and navigation.",
+		Type:        gig.TypeTask,
+		Priority:    gig.P1,
+		ParentID:    launch.ID,
+		Assignee:    "priya",
+		Labels:      []string{"frontend", "design"},
+		CreatedBy:   "seed",
+	})
+
+	deploy, _ := store.Create(gig.CreateParams{
+		Title:       "Setup CI/CD pipeline",
+		Description: "GitHub Actions → Docker → ECS with staging and prod environments.",
+		Type:        gig.TypeChore,
+		Priority:    gig.P1,
+		ParentID:    launch.ID,
+		Assignee:    "neeraj",
+		Labels:      []string{"infra", "devops"},
+		CreatedBy:   "seed",
+	})
+	store.UpdateStatus(deploy.ID, gig.StatusBlocked, "seed")
+
+	// Nested subtasks under auth: auth.1, auth.2, auth.3
+	store.Create(gig.CreateParams{
+		Title:    "Setup OAuth provider config",
+		Type:     gig.TypeTask,
+		Priority: gig.P1,
+		ParentID: auth.ID,
+		Assignee: "neeraj",
+		Labels:   []string{"backend"},
+		CreatedBy: "seed",
+	})
+
+	jwtTask, _ := store.Create(gig.CreateParams{
+		Title:    "Implement JWT middleware",
+		Type:     gig.TypeTask,
+		Priority: gig.P0,
+		ParentID: auth.ID,
+		Assignee: "neeraj",
+		Labels:   []string{"backend", "security"},
+		CreatedBy: "seed",
+	})
+	store.UpdateStatus(jwtTask.ID, gig.StatusInProgress, "seed")
+
+	refreshTask, _ := store.Create(gig.CreateParams{
+		Title:    "Add refresh token rotation",
+		Type:     gig.TypeTask,
+		Priority: gig.P1,
+		ParentID: auth.ID,
+		Assignee: "neeraj",
+		CreatedBy: "seed",
+	})
+
+	// Nested subtasks under API: api.1, api.2
+	usersEndpoint, _ := store.Create(gig.CreateParams{
+		Title:    "Users CRUD endpoints",
+		Type:     gig.TypeTask,
+		Priority: gig.P1,
+		ParentID: api.ID,
+		Assignee: "jeff",
+		Labels:   []string{"backend"},
+		CreatedBy: "seed",
+	})
+	store.UpdateStatus(usersEndpoint.ID, gig.StatusClosed, "seed")
+	store.CloseTask(usersEndpoint.ID, "completed", "seed")
+
+	store.Create(gig.CreateParams{
+		Title:    "Projects CRUD endpoints",
+		Type:     gig.TypeTask,
+		Priority: gig.P1,
+		ParentID: api.ID,
+		Assignee: "jeff",
+		Labels:   []string{"backend"},
+		CreatedBy: "seed",
+	})
+
+	// ── Epic 2: Observability ────────────────────────────────────────
+	obs, _ := store.Create(gig.CreateParams{
+		Title:       "Observability & Monitoring",
+		Description: "Logging, metrics, and alerting infrastructure.",
+		Type:        gig.TypeEpic,
+		Priority:    gig.P1,
+		Assignee:    "jeff",
+		Labels:      []string{"infra", "observability"},
+		CreatedBy:   "seed",
+	})
+
+	logging, _ := store.Create(gig.CreateParams{
+		Title:    "Structured logging setup",
+		Type:     gig.TypeTask,
+		Priority: gig.P1,
+		ParentID: obs.ID,
+		Assignee: "jeff",
+		Labels:   []string{"backend"},
+		CreatedBy: "seed",
+	})
+	store.UpdateStatus(logging.ID, gig.StatusClosed, "seed")
+	store.CloseTask(logging.ID, "shipped in v0.9", "seed")
+
+	metrics, _ := store.Create(gig.CreateParams{
+		Title:       "Prometheus metrics integration",
+		Description: "Instrument HTTP handlers and DB queries with Prometheus counters/histograms.",
+		Type:        gig.TypeFeature,
+		Priority:    gig.P2,
+		ParentID:    obs.ID,
+		Assignee:    "jeff",
+		Labels:      []string{"backend", "metrics"},
+		CreatedBy:   "seed",
+	})
+
+	store.Create(gig.CreateParams{
+		Title:    "Grafana dashboard templates",
+		Type:     gig.TypeTask,
+		Priority: gig.P3,
+		ParentID: obs.ID,
+		Labels:   []string{"infra", "dashboards"},
+		CreatedBy: "seed",
+	})
+	store.UpdateStatus(obs.ID, gig.StatusInProgress, "seed")
+
+	// ── Standalone tasks (no parent) ─────────────────────────────────
+	bug, _ := store.Create(gig.CreateParams{
+		Title:       "Fix memory leak in websocket handler",
+		Description: "Connection pool not releasing idle connections after timeout.",
+		Type:        gig.TypeBug,
+		Priority:    gig.P0,
+		Assignee:    "neeraj",
+		Labels:      []string{"backend", "critical"},
+		CreatedBy:   "seed",
+	})
+	store.UpdateStatus(bug.ID, gig.StatusInProgress, "seed")
+
+	store.Create(gig.CreateParams{
+		Title:       "Evaluate message queue options",
+		Description: "Compare NATS, RabbitMQ, and Redis Streams for async job processing.",
+		Type:        gig.TypeTask,
+		Priority:    gig.P3,
+		Labels:      []string{"research", "infra"},
+		CreatedBy:   "seed",
+	})
+	store.UpdateStatus(ui.ID, gig.StatusDeferred, "seed")
+
+	store.Create(gig.CreateParams{
+		Title:       "Write API documentation",
+		Description: "OpenAPI spec + usage examples for all public endpoints.",
+		Type:        gig.TypeChore,
+		Priority:    gig.P2,
+		Assignee:    "priya",
+		Labels:      []string{"docs"},
+		CreatedBy:   "seed",
+	})
+
+	migrationBug, _ := store.Create(gig.CreateParams{
+		Title:       "Database migration fails on empty schema",
+		Description: "First-time setup crashes when schema_migrations table doesn't exist.",
+		Type:        gig.TypeBug,
+		Priority:    gig.P1,
+		Assignee:    "jeff",
+		Labels:      []string{"backend", "bug"},
+		CreatedBy:   "seed",
+	})
+	store.CloseTask(migrationBug.ID, "fixed in commit abc123", "seed")
+
+	// ── Dependencies ─────────────────────────────────────────────────
+	// CI/CD blocked by auth completion
+	store.AddDependency(deploy.ID, auth.ID, gig.Blocks)
+	// Refresh tokens depend on JWT middleware
+	store.AddDependency(refreshTask.ID, jwtTask.ID, gig.Blocks)
+	// Metrics depends on logging
+	store.AddDependency(metrics.ID, logging.ID, gig.Blocks)
+
+	// ── Comments ─────────────────────────────────────────────────────
+	store.AddComment(auth.ID, "neeraj", "Started with Google OAuth, will add GitHub later.")
+	store.AddComment(auth.ID, "jeff", "Make sure to handle token expiry edge cases.")
+	store.AddComment(bug.ID, "neeraj", "Reproduced locally — goroutine leak in the upgrade handler.")
+	store.AddComment(deploy.ID, "priya", "Can we use the existing Terraform modules?")
+	store.AddComment(launch.ID, "neeraj", "Targeting end of Q1 for v1.0 release.")
+
+	log.Println("Demo data seeded successfully.")
+}

--- a/examples/gig-controller/templates/board.html
+++ b/examples/gig-controller/templates/board.html
@@ -1,0 +1,72 @@
+{{define "board.html"}}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>gig controller</title>
+    <link rel="stylesheet" href="/static/style.css">
+    <script src="https://unpkg.com/htmx.org@2.0.4"></script>
+</head>
+<body>
+    <nav class="navbar">
+        <div class="nav-left">
+            <a href="/" class="logo">gig</a>
+            <span class="nav-stats">{{.TotalCount}} tasks &middot; {{.ReadyCount}} ready</span>
+        </div>
+        <div class="nav-right">
+            <div class="view-toggle">
+                <a href="/?view=top" class="btn btn-toggle {{if eq .View "top"}}btn-toggle-active{{end}}">Top-Level</a>
+                <a href="/?view=all" class="btn btn-toggle {{if eq .View "all"}}btn-toggle-active{{end}}">All Tasks</a>
+            </div>
+            <a href="/new" class="btn btn-primary">+ New Task</a>
+        </div>
+    </nav>
+
+    <div class="board" id="board">
+        {{range .Columns}}
+        <div class="column" data-status="{{.Status}}"
+             ondragover="event.preventDefault(); this.classList.add('column-dragover');"
+             ondragleave="this.classList.remove('column-dragover');"
+             ondrop="dropCard(event, this);">
+            <div class="column-header" style="border-top: 3px solid {{columnColor .Status}}">
+                <span class="column-title">
+                    <span class="column-dot" style="background: {{columnColor .Status}}"></span>
+                    {{statusLabel .Status}}
+                </span>
+                <span class="column-count badge-status-{{.Status}}">{{len .Tasks}}</span>
+            </div>
+            <div class="column-body"
+                 ondragover="event.preventDefault();"
+                 ondrop="dropCard(event, this.closest('.column'));">
+                {{range .Tasks}}
+                {{template "card.html" .}}
+                {{end}}
+                {{if not .Tasks}}
+                <div class="empty-column">No tasks</div>
+                {{end}}
+            </div>
+        </div>
+        {{end}}
+    </div>
+
+    <script>
+    function dropCard(event, column) {
+        event.preventDefault();
+        column.classList.remove('column-dragover');
+        var taskId = event.dataTransfer.getData('text/plain');
+        var newStatus = column.dataset.status;
+        if (!taskId || !newStatus) return;
+
+        fetch('/task/' + taskId + '/status', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+            body: 'status=' + encodeURIComponent(newStatus)
+        }).then(function() {
+            window.location.reload();
+        });
+    }
+    </script>
+</body>
+</html>
+{{end}}

--- a/examples/gig-controller/templates/create.html
+++ b/examples/gig-controller/templates/create.html
@@ -1,0 +1,92 @@
+{{define "create.html"}}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>New Task — gig</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+    <nav class="navbar">
+        <div class="nav-left">
+            <a href="/" class="logo">gig</a>
+            <span class="nav-breadcrumb">
+                <a href="/">Board</a> / New Task
+            </span>
+        </div>
+    </nav>
+
+    <div class="form-container">
+        <h2>Create Task</h2>
+        <form method="POST" action="/new" class="task-form">
+            <div class="form-group">
+                <label for="title">Title *</label>
+                <input type="text" id="title" name="title" class="input" required autofocus>
+            </div>
+
+            <div class="form-group">
+                <label for="description">Description</label>
+                <textarea id="description" name="description" class="input textarea" rows="3"></textarea>
+            </div>
+
+            <div class="form-row">
+                <div class="form-group">
+                    <label for="type">Type</label>
+                    <select id="type" name="type" class="input">
+                        <option value="task">Task</option>
+                        <option value="bug">Bug</option>
+                        <option value="feature">Feature</option>
+                        <option value="epic">Epic</option>
+                        <option value="chore">Chore</option>
+                    </select>
+                </div>
+
+                <div class="form-group">
+                    <label for="priority">Priority</label>
+                    <select id="priority" name="priority" class="input">
+                        <option value="0">P0 — Critical</option>
+                        <option value="1">P1 — High</option>
+                        <option value="2" selected>P2 — Medium</option>
+                        <option value="3">P3 — Low</option>
+                        <option value="4">P4 — Backlog</option>
+                    </select>
+                </div>
+            </div>
+
+            <div class="form-row">
+                <div class="form-group">
+                    <label for="assignee">Assignee</label>
+                    <input type="text" id="assignee" name="assignee" class="input" placeholder="e.g. neeraj">
+                </div>
+
+                <div class="form-group">
+                    <label for="parent">Parent Task</label>
+                    <select id="parent" name="parent" class="input">
+                        <option value="">None</option>
+                        {{range .AllTasks}}
+                        <option value="{{.ID}}">{{.ID}} — {{.Title}}</option>
+                        {{end}}
+                    </select>
+                </div>
+            </div>
+
+            <div class="form-group">
+                <label for="labels">Labels</label>
+                <input type="text" id="labels" name="labels" class="input" placeholder="comma-separated: backend, urgent">
+            </div>
+
+            <div class="form-group">
+                <label for="notes">Notes</label>
+                <textarea id="notes" name="notes" class="input textarea" rows="2"></textarea>
+            </div>
+
+            <div class="form-actions">
+                <a href="/" class="btn btn-secondary">Cancel</a>
+                <button type="submit" class="btn btn-primary">Create Task</button>
+            </div>
+        </form>
+    </div>
+</body>
+</html>
+{{end}}

--- a/examples/gig-controller/templates/detail.html
+++ b/examples/gig-controller/templates/detail.html
@@ -1,0 +1,202 @@
+{{define "detail.html"}}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{.Task.Title}} — gig</title>
+    <link rel="stylesheet" href="/static/style.css">
+    <script src="https://unpkg.com/htmx.org@2.0.4"></script>
+</head>
+<body>
+    <nav class="navbar">
+        <div class="nav-left">
+            <a href="/" class="logo">gig</a>
+            <span class="nav-breadcrumb">
+                <a href="/">Board</a> / {{.Task.ID}}
+            </span>
+        </div>
+        <div class="nav-right">
+            <a href="/task/{{.Task.ID}}/edit" class="btn btn-secondary">Edit</a>
+        </div>
+    </nav>
+
+    <div class="detail-layout">
+        <div class="detail-main">
+            <div class="detail-header">
+                <h1>{{.Task.Title}}</h1>
+                <div class="detail-badges">
+                    <span class="badge {{priorityClass .Task.Priority}}">{{priorityLabel .Task.Priority}}</span>
+                    <span class="badge badge-type">{{.Task.Type}}</span>
+                    <span class="badge badge-status badge-status-{{.Task.Status}}">
+                        {{statusIcon .Task.Status}} {{statusLabel .Task.Status}}
+                    </span>
+                </div>
+            </div>
+
+            {{if .Task.Description}}
+            <div class="detail-section">
+                <h3>Description</h3>
+                <p>{{.Task.Description}}</p>
+            </div>
+            {{end}}
+
+            {{if .Task.Notes}}
+            <div class="detail-section">
+                <h3>Notes</h3>
+                <p>{{.Task.Notes}}</p>
+            </div>
+            {{end}}
+
+            <!-- Children (subtasks) — mini kanban -->
+            {{if .Children}}
+            <div class="detail-section">
+                <h3>Subtasks ({{len .Children}})</h3>
+                <div class="mini-board">
+                    {{range .ChildrenColumns}}
+                    <div class="mini-column" data-status="{{.Status}}"
+                         ondragover="event.preventDefault(); this.classList.add('column-dragover');"
+                         ondragleave="this.classList.remove('column-dragover');"
+                         ondrop="dropCard(event, this);">
+                        <div class="mini-column-header" style="border-top: 2px solid {{columnColor .Status}}">
+                            <span class="mini-column-title">{{statusLabel .Status}}</span>
+                            <span class="column-count badge-status-{{.Status}}">{{len .Tasks}}</span>
+                        </div>
+                        <div class="mini-column-body"
+                             ondragover="event.preventDefault();"
+                             ondrop="dropCard(event, this.closest('.mini-column'));">
+                            {{range .Tasks}}
+                            {{template "card.html" .}}
+                            {{end}}
+                        </div>
+                    </div>
+                    {{end}}
+                </div>
+            </div>
+            <script>
+            function dropCard(event, column) {
+                event.preventDefault();
+                column.classList.remove('column-dragover');
+                var taskId = event.dataTransfer.getData('text/plain');
+                var newStatus = column.dataset.status;
+                if (!taskId || !newStatus) return;
+
+                fetch('/task/' + taskId + '/status', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+                    body: 'status=' + encodeURIComponent(newStatus)
+                }).then(function() {
+                    window.location.reload();
+                });
+            }
+            </script>
+            {{end}}
+
+            <!-- Comments -->
+            <div class="detail-section">
+                <h3>Comments</h3>
+                {{template "comments.html" .Comments}}
+
+                <form class="comment-form" hx-post="/task/{{.Task.ID}}/comment" hx-target="#comments-list" hx-swap="outerHTML">
+                    <input type="text" name="author" placeholder="Your name" class="input input-sm">
+                    <div class="comment-form-row">
+                        <input type="text" name="content" placeholder="Add a comment..." class="input" required>
+                        <button type="submit" class="btn btn-primary">Send</button>
+                    </div>
+                </form>
+            </div>
+
+            <!-- Events -->
+            {{if .Events}}
+            <div class="detail-section">
+                <h3>Activity</h3>
+                <div class="events-list">
+                    {{range .Events}}
+                    <div class="event-item">
+                        <span class="event-time">{{.Timestamp.Format "Jan 2, 15:04"}}</span>
+                        <span class="event-type">{{.Type}}</span>
+                        {{if .Field}}
+                        <span class="muted">{{.Field}}: {{.OldValue}} → {{.NewValue}}</span>
+                        {{end}}
+                        {{if .Actor}}<span class="muted">by {{.Actor}}</span>{{end}}
+                    </div>
+                    {{end}}
+                </div>
+            </div>
+            {{end}}
+        </div>
+
+        <div class="detail-sidebar">
+            <!-- Meta info -->
+            <div class="sidebar-section">
+                <h4>Details</h4>
+                <dl class="meta-list">
+                    <dt>ID</dt><dd>{{.Task.ID}}</dd>
+                    <dt>Status</dt><dd>{{statusLabel .Task.Status}}</dd>
+                    <dt>Priority</dt><dd>{{.Task.Priority}}</dd>
+                    <dt>Type</dt><dd>{{.Task.Type}}</dd>
+                    {{if .Task.Assignee}}<dt>Assignee</dt><dd>@{{.Task.Assignee}}</dd>{{end}}
+                    {{if .Task.ParentID}}<dt>Parent</dt><dd><a href="/task/{{.Task.ParentID}}">{{.Task.ParentID}}</a></dd>{{end}}
+                    {{if .Task.Labels}}<dt>Labels</dt><dd>{{range .Task.Labels}}<span class="label">{{.}}</span> {{end}}</dd>{{end}}
+                    <dt>Created</dt><dd>{{.Task.CreatedAt.Format "Jan 2, 2006 15:04"}}</dd>
+                    <dt>Updated</dt><dd>{{.Task.UpdatedAt.Format "Jan 2, 2006 15:04"}}</dd>
+                    {{if .Task.ClosedAt}}<dt>Closed</dt><dd>{{.Task.ClosedAt.Format "Jan 2, 2006 15:04"}}</dd>{{end}}
+                    {{if .Task.CloseReason}}<dt>Reason</dt><dd>{{.Task.CloseReason}}</dd>{{end}}
+                </dl>
+            </div>
+
+            <!-- Actions -->
+            <div class="sidebar-section">
+                <h4>Actions</h4>
+
+                {{if ne .Task.Status "closed"}}
+                <form hx-post="/task/{{.Task.ID}}/status" hx-target="body" class="action-form">
+                    <label>Change Status</label>
+                    <select name="status" onchange="this.form.requestSubmit()">
+                        <option value="">-- select --</option>
+                        <option value="open">Open</option>
+                        <option value="in_progress">In Progress</option>
+                        <option value="blocked">Blocked</option>
+                        <option value="deferred">Deferred</option>
+                    </select>
+                </form>
+
+                <form hx-post="/task/{{.Task.ID}}/close" hx-target="body" class="action-form">
+                    <button type="submit" class="btn btn-danger btn-full">Close Task</button>
+                </form>
+                {{else}}
+                <form hx-post="/task/{{.Task.ID}}/reopen" hx-target="body" class="action-form">
+                    <button type="submit" class="btn btn-secondary btn-full">Reopen Task</button>
+                </form>
+                {{end}}
+            </div>
+
+            <!-- Dependencies -->
+            {{if .DepsOn}}
+            <div class="sidebar-section">
+                <h4>Depends On</h4>
+                {{range .DepsOn}}
+                <a href="/task/{{.Task.ID}}" class="dep-link">
+                    <span style="color: {{columnColor .Task.Status}}">{{statusIcon .Task.Status}}</span>
+                    {{.Task.Title}}
+                </a>
+                {{end}}
+            </div>
+            {{end}}
+
+            {{if .Blocks}}
+            <div class="sidebar-section">
+                <h4>Blocks</h4>
+                {{range .Blocks}}
+                <a href="/task/{{.Task.ID}}" class="dep-link">
+                    <span style="color: {{columnColor .Task.Status}}">{{statusIcon .Task.Status}}</span>
+                    {{.Task.Title}}
+                </a>
+                {{end}}
+            </div>
+            {{end}}
+        </div>
+    </div>
+</body>
+</html>
+{{end}}

--- a/examples/gig-controller/templates/edit.html
+++ b/examples/gig-controller/templates/edit.html
@@ -1,0 +1,69 @@
+{{define "edit.html"}}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Edit {{.Task.Title}} — gig</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+    <nav class="navbar">
+        <div class="nav-left">
+            <a href="/" class="logo">gig</a>
+            <span class="nav-breadcrumb">
+                <a href="/">Board</a> / <a href="/task/{{.Task.ID}}">{{.Task.ID}}</a> / Edit
+            </span>
+        </div>
+    </nav>
+
+    <div class="form-container">
+        <h2>Edit Task</h2>
+        <form method="POST" action="/task/{{.Task.ID}}/edit" class="task-form">
+            <div class="form-group">
+                <label for="title">Title</label>
+                <input type="text" id="title" name="title" class="input" value="{{.Task.Title}}" required>
+            </div>
+
+            <div class="form-group">
+                <label for="description">Description</label>
+                <textarea id="description" name="description" class="input textarea" rows="3">{{.Task.Description}}</textarea>
+            </div>
+
+            <div class="form-row">
+                <div class="form-group">
+                    <label for="priority">Priority</label>
+                    <select id="priority" name="priority" class="input">
+                        <option value="0" {{if eq .Task.Priority 0}}selected{{end}}>P0 — Critical</option>
+                        <option value="1" {{if eq .Task.Priority 1}}selected{{end}}>P1 — High</option>
+                        <option value="2" {{if eq .Task.Priority 2}}selected{{end}}>P2 — Medium</option>
+                        <option value="3" {{if eq .Task.Priority 3}}selected{{end}}>P3 — Low</option>
+                        <option value="4" {{if eq .Task.Priority 4}}selected{{end}}>P4 — Backlog</option>
+                    </select>
+                </div>
+
+                <div class="form-group">
+                    <label for="assignee">Assignee</label>
+                    <input type="text" id="assignee" name="assignee" class="input" value="{{.Task.Assignee}}">
+                </div>
+            </div>
+
+            <div class="form-group">
+                <label for="labels">Labels</label>
+                <input type="text" id="labels" name="labels" class="input" value="{{range $i, $l := .Task.Labels}}{{if $i}}, {{end}}{{$l}}{{end}}">
+            </div>
+
+            <div class="form-group">
+                <label for="notes">Notes</label>
+                <textarea id="notes" name="notes" class="input textarea" rows="3">{{.Task.Notes}}</textarea>
+            </div>
+
+            <div class="form-actions">
+                <a href="/task/{{.Task.ID}}" class="btn btn-secondary">Cancel</a>
+                <button type="submit" class="btn btn-primary">Save Changes</button>
+            </div>
+        </form>
+    </div>
+</body>
+</html>
+{{end}}

--- a/examples/gig-controller/templates/partials/card.html
+++ b/examples/gig-controller/templates/partials/card.html
@@ -1,0 +1,15 @@
+{{define "card.html"}}
+<a href="/task/{{.ID}}" class="card status-{{.Status}}" draggable="true" data-task-id="{{.ID}}"
+   ondragstart="event.dataTransfer.setData('text/plain', this.dataset.taskId); this.classList.add('dragging');"
+   ondragend="this.classList.remove('dragging');">
+    <div class="card-header">
+        <span class="badge {{priorityClass .Priority}}">{{priorityLabel .Priority}}</span>
+        <span class="card-type">{{.Type}}</span>
+    </div>
+    <div class="card-title">{{.Title}}</div>
+    <div class="card-footer">
+        <span class="card-id">{{.ID}}</span>
+        {{if .Assignee}}<span class="card-assignee">@{{.Assignee}}</span>{{end}}
+    </div>
+</a>
+{{end}}

--- a/examples/gig-controller/templates/partials/comments.html
+++ b/examples/gig-controller/templates/partials/comments.html
@@ -1,0 +1,16 @@
+{{define "comments.html"}}
+<div class="comments-list" id="comments-list">
+    {{range .}}
+    <div class="comment">
+        <div class="comment-meta">
+            <strong>{{if .Author}}{{.Author}}{{else}}anonymous{{end}}</strong>
+            <span class="comment-time">{{.CreatedAt.Format "Jan 2, 15:04"}}</span>
+        </div>
+        <div class="comment-body">{{.Content}}</div>
+    </div>
+    {{end}}
+    {{if not .}}
+    <p class="muted">No comments yet.</p>
+    {{end}}
+</div>
+{{end}}

--- a/examples/gig-controller/templates/static/style.css
+++ b/examples/gig-controller/templates/static/style.css
@@ -1,0 +1,412 @@
+/* Reset & Base */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+    --bg: #0d1117;
+    --bg-surface: #161b22;
+    --bg-card: #1c2128;
+    --bg-hover: #252b33;
+    --border: #30363d;
+    --text: #e6edf3;
+    --text-muted: #7d8590;
+    --accent: #58a6ff;
+    --danger: #f85149;
+    --success: #3fb950;
+    --warning: #d29922;
+    --radius: 8px;
+    --font: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+
+    /* Status colors */
+    --status-open: #8b949e;
+    --status-open-bg: #8b949e18;
+    --status-in-progress: #58a6ff;
+    --status-in-progress-bg: #58a6ff18;
+    --status-blocked: #f85149;
+    --status-blocked-bg: #f8514918;
+    --status-deferred: #d29922;
+    --status-deferred-bg: #d2992218;
+    --status-closed: #3fb950;
+    --status-closed-bg: #3fb95018;
+}
+
+body {
+    font-family: var(--font);
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.5;
+    min-height: 100vh;
+}
+
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+/* Navbar */
+.navbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 12px 24px;
+    background: var(--bg-surface);
+    border-bottom: 1px solid var(--border);
+    position: sticky;
+    top: 0;
+    z-index: 10;
+}
+
+.nav-left { display: flex; align-items: center; gap: 16px; }
+.nav-right { display: flex; align-items: center; gap: 8px; }
+
+.logo {
+    font-size: 20px;
+    font-weight: 700;
+    color: var(--text);
+    letter-spacing: -0.5px;
+}
+.logo:hover { text-decoration: none; color: var(--accent); }
+
+.nav-stats { color: var(--text-muted); font-size: 13px; }
+.nav-breadcrumb { color: var(--text-muted); font-size: 14px; }
+.nav-breadcrumb a { color: var(--text-muted); }
+.nav-breadcrumb a:hover { color: var(--accent); }
+
+/* Buttons */
+.btn {
+    display: inline-flex;
+    align-items: center;
+    padding: 6px 14px;
+    border-radius: 6px;
+    font-size: 13px;
+    font-weight: 500;
+    border: 1px solid var(--border);
+    cursor: pointer;
+    background: var(--bg-card);
+    color: var(--text);
+    text-decoration: none;
+    transition: background 0.15s;
+}
+.btn:hover { background: var(--bg-hover); text-decoration: none; }
+.btn-primary { background: #238636; border-color: #2ea043; color: #fff; }
+.btn-primary:hover { background: #2ea043; }
+.btn-danger { background: #da3633; border-color: #f85149; color: #fff; }
+.btn-danger:hover { background: #f85149; }
+.btn-secondary { background: var(--bg-surface); }
+.btn-full { width: 100%; justify-content: center; }
+
+/* Board */
+.board {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 12px;
+    padding: 20px 24px;
+    min-height: calc(100vh - 56px);
+    align-items: start;
+}
+
+.column {
+    background: var(--bg-surface);
+    border-radius: var(--radius);
+    border: 1px solid var(--border);
+    min-height: 200px;
+}
+
+.column-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 12px 14px;
+    border-bottom: 1px solid var(--border);
+    border-radius: var(--radius) var(--radius) 0 0;
+}
+
+.column-title {
+    font-size: 13px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+.column-title .column-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    display: inline-block;
+}
+.column-count {
+    padding: 2px 8px;
+    border-radius: 12px;
+    font-size: 12px;
+    font-weight: 600;
+}
+
+.column-body { padding: 8px; display: flex; flex-direction: column; gap: 6px; }
+
+.empty-column { color: var(--text-muted); font-size: 13px; text-align: center; padding: 24px 8px; }
+
+/* Cards */
+.card {
+    display: block;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-left: 3px solid var(--border);
+    border-radius: 6px;
+    padding: 10px 12px;
+    cursor: pointer;
+    transition: border-color 0.15s, background 0.15s;
+    text-decoration: none;
+    color: var(--text);
+}
+.card:hover { border-color: var(--accent); border-left-color: var(--accent); background: var(--bg-hover); text-decoration: none; cursor: grab; }
+.card.dragging { opacity: 0.4; }
+.column-dragover, .mini-column.column-dragover { background: var(--bg-hover); outline: 2px dashed var(--accent); outline-offset: -2px; }
+
+.card.status-open { border-left-color: var(--status-open); }
+.card.status-in_progress { border-left-color: var(--status-in-progress); background: var(--status-in-progress-bg); }
+.card.status-blocked { border-left-color: var(--status-blocked); background: var(--status-blocked-bg); }
+.card.status-deferred { border-left-color: var(--status-deferred); background: var(--status-deferred-bg); }
+.card.status-closed { border-left-color: var(--status-closed); opacity: 0.7; }
+
+.card-header { display: flex; align-items: center; gap: 6px; margin-bottom: 4px; }
+.card-title { font-size: 13px; font-weight: 500; line-height: 1.4; }
+.card-footer { display: flex; justify-content: space-between; align-items: center; margin-top: 6px; }
+.card-id { font-size: 11px; color: var(--text-muted); font-family: monospace; }
+.card-assignee { font-size: 11px; color: var(--accent); }
+.card-type { font-size: 11px; color: var(--text-muted); }
+.card-status-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    display: inline-block;
+    flex-shrink: 0;
+}
+
+/* Badges */
+.badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 1px 6px;
+    border-radius: 4px;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+}
+
+.priority-critical { background: #f8514922; color: #f85149; }
+.priority-high { background: #d2992222; color: #d29922; }
+.priority-medium { background: #58a6ff22; color: #58a6ff; }
+.priority-low { background: #3fb95022; color: #3fb950; }
+.priority-backlog { background: #7d859022; color: #7d8590; }
+
+.badge-type { background: var(--bg-surface); color: var(--text-muted); }
+.badge-status { border: 1px solid; background: transparent; }
+.badge-status-open { border-color: var(--status-open); color: var(--status-open); background: var(--status-open-bg); }
+.badge-status-in_progress { border-color: var(--status-in-progress); color: var(--status-in-progress); background: var(--status-in-progress-bg); }
+.badge-status-blocked { border-color: var(--status-blocked); color: var(--status-blocked); background: var(--status-blocked-bg); }
+.badge-status-deferred { border-color: var(--status-deferred); color: var(--status-deferred); background: var(--status-deferred-bg); }
+.badge-status-closed { border-color: var(--status-closed); color: var(--status-closed); background: var(--status-closed-bg); }
+
+.label {
+    display: inline-block;
+    padding: 1px 6px;
+    border-radius: 12px;
+    font-size: 11px;
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    color: var(--text-muted);
+    margin-right: 4px;
+}
+
+/* Detail Layout */
+.detail-layout {
+    display: grid;
+    grid-template-columns: 1fr 300px;
+    gap: 24px;
+    padding: 24px;
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+.detail-header { margin-bottom: 20px; }
+.detail-header h1 { font-size: 24px; font-weight: 600; margin-bottom: 8px; }
+.detail-badges { display: flex; gap: 8px; flex-wrap: wrap; }
+
+.detail-section {
+    margin-bottom: 24px;
+    padding-bottom: 24px;
+    border-bottom: 1px solid var(--border);
+}
+.detail-section h3 {
+    font-size: 14px;
+    font-weight: 600;
+    margin-bottom: 10px;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+}
+.detail-section p { font-size: 14px; color: var(--text); }
+
+/* Sidebar */
+.detail-sidebar {
+    position: sticky;
+    top: 80px;
+    align-self: start;
+}
+
+.sidebar-section {
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 14px;
+    margin-bottom: 12px;
+}
+
+.sidebar-section h4 {
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--text-muted);
+    margin-bottom: 10px;
+}
+
+.meta-list { display: grid; grid-template-columns: 80px 1fr; gap: 4px 8px; font-size: 13px; }
+.meta-list dt { color: var(--text-muted); }
+.meta-list dd { color: var(--text); }
+
+.dep-link {
+    display: block;
+    font-size: 13px;
+    padding: 4px 0;
+    color: var(--text);
+}
+.dep-link:hover { color: var(--accent); }
+
+/* View Toggle */
+.view-toggle { display: flex; gap: 0; margin-right: 8px; }
+.btn-toggle {
+    padding: 5px 12px;
+    font-size: 12px;
+    border-radius: 0;
+    border: 1px solid var(--border);
+    background: var(--bg-card);
+    color: var(--text-muted);
+}
+.btn-toggle:first-child { border-radius: 6px 0 0 6px; }
+.btn-toggle:last-child { border-radius: 0 6px 6px 0; border-left: none; }
+.btn-toggle-active { background: var(--accent); color: #fff; border-color: var(--accent); }
+.btn-toggle:hover { text-decoration: none; }
+
+/* Mini Kanban (subtasks in detail view) */
+.mini-board {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 8px;
+}
+.mini-column {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    min-height: 80px;
+}
+.mini-column-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 8px 10px;
+    border-bottom: 1px solid var(--border);
+    border-radius: 6px 6px 0 0;
+}
+.mini-column-title {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--text-muted);
+}
+.mini-column-body {
+    padding: 6px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+/* Comments */
+.comment {
+    padding: 10px 0;
+    border-bottom: 1px solid var(--border);
+}
+.comment:last-child { border-bottom: none; }
+.comment-meta { font-size: 13px; margin-bottom: 4px; }
+.comment-meta strong { color: var(--text); }
+.comment-time { color: var(--text-muted); font-size: 12px; margin-left: 8px; }
+.comment-body { font-size: 14px; color: var(--text); }
+
+.comment-form { margin-top: 12px; }
+.comment-form-row { display: flex; gap: 8px; margin-top: 6px; }
+.comment-form-row .input { flex: 1; }
+
+/* Events */
+.events-list { font-size: 13px; }
+.event-item { padding: 4px 0; display: flex; gap: 8px; align-items: baseline; }
+.event-time { color: var(--text-muted); font-size: 12px; font-family: monospace; white-space: nowrap; }
+.event-type { font-weight: 500; }
+
+/* Forms */
+.form-container {
+    max-width: 640px;
+    margin: 32px auto;
+    padding: 0 24px;
+}
+.form-container h2 { font-size: 20px; margin-bottom: 20px; }
+
+.task-form { display: flex; flex-direction: column; gap: 16px; }
+.form-group { display: flex; flex-direction: column; gap: 4px; }
+.form-group label { font-size: 13px; font-weight: 500; color: var(--text-muted); }
+
+.form-row { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+
+.input {
+    padding: 8px 12px;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    color: var(--text);
+    font-size: 14px;
+    font-family: var(--font);
+}
+.input:focus { outline: none; border-color: var(--accent); }
+.input-sm { padding: 4px 8px; font-size: 12px; max-width: 160px; }
+.textarea { resize: vertical; }
+
+select.input { cursor: pointer; }
+
+.form-actions { display: flex; gap: 8px; justify-content: flex-end; padding-top: 8px; }
+
+.action-form { margin-bottom: 8px; }
+.action-form label { font-size: 12px; color: var(--text-muted); display: block; margin-bottom: 4px; }
+.action-form select {
+    width: 100%;
+    padding: 6px 8px;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    color: var(--text);
+    font-size: 13px;
+    cursor: pointer;
+}
+
+.muted { color: var(--text-muted); font-size: 13px; }
+
+/* Responsive */
+@media (max-width: 1024px) {
+    .board { grid-template-columns: repeat(3, 1fr); }
+    .detail-layout { grid-template-columns: 1fr; }
+    .detail-sidebar { position: static; }
+}
+
+@media (max-width: 640px) {
+    .board { grid-template-columns: 1fr; }
+    .form-row { grid-template-columns: 1fr; }
+}

--- a/ui/server.go
+++ b/ui/server.go
@@ -1,0 +1,465 @@
+// Package ui provides an embedded web-based kanban board for gig.
+// Usage:
+//
+//	server := ui.New(store)
+//	server.ListenAndServe(":9741")
+package ui
+
+import (
+	"embed"
+	"html/template"
+	"net/http"
+	"strings"
+
+	"github.com/neerajg/gig"
+)
+
+//go:embed templates/*
+var templateFS embed.FS
+
+// Column represents a kanban column for template rendering.
+type Column struct {
+	Status gig.Status
+	Tasks  []*gig.Task
+}
+
+// BoardData is the template data for the board view.
+type BoardData struct {
+	Columns    []Column
+	ReadyCount int
+	TotalCount int
+	View       string
+}
+
+// DetailData is the template data for the task detail view.
+type DetailData struct {
+	Task            *gig.Task
+	Comments        []*gig.Comment
+	DepsOn          []*DepInfo
+	Blocks          []*DepInfo
+	Children        []*gig.Task
+	ChildrenColumns []Column
+	Events          []*gig.Event
+	AllTasks        []*gig.Task
+}
+
+// DepInfo pairs a dependency with its task info.
+type DepInfo struct {
+	Task *gig.Task
+	Dep  *gig.Dependency
+}
+
+// Server is the gig web UI server.
+type Server struct {
+	store *gig.Store
+	tmpl  *template.Template
+	mux   *http.ServeMux
+}
+
+// New creates a new web UI server backed by the given store.
+func New(store *gig.Store) *Server {
+	s := &Server{store: store}
+	s.parseTemplates()
+	s.setupRoutes()
+	return s
+}
+
+// ListenAndServe starts the HTTP server on the given address (e.g. ":9741").
+func (s *Server) ListenAndServe(addr string) error {
+	return http.ListenAndServe(addr, s.mux)
+}
+
+// Handler returns the http.Handler for use with custom servers.
+func (s *Server) Handler() http.Handler {
+	return s.mux
+}
+
+var funcMap = template.FuncMap{
+	"statusIcon": func(st gig.Status) string {
+		switch st {
+		case gig.StatusOpen:
+			return "○"
+		case gig.StatusInProgress:
+			return "◉"
+		case gig.StatusBlocked:
+			return "⊘"
+		case gig.StatusDeferred:
+			return "◌"
+		case gig.StatusClosed:
+			return "✓"
+		default:
+			return "?"
+		}
+	},
+	"priorityClass": func(p gig.Priority) string {
+		switch p {
+		case gig.P0:
+			return "priority-critical"
+		case gig.P1:
+			return "priority-high"
+		case gig.P2:
+			return "priority-medium"
+		case gig.P3:
+			return "priority-low"
+		case gig.P4:
+			return "priority-backlog"
+		default:
+			return ""
+		}
+	},
+	"priorityLabel": func(p gig.Priority) string {
+		switch p {
+		case gig.P0:
+			return "P0"
+		case gig.P1:
+			return "P1"
+		case gig.P2:
+			return "P2"
+		case gig.P3:
+			return "P3"
+		case gig.P4:
+			return "P4"
+		default:
+			return "?"
+		}
+	},
+	"statusLabel": func(st gig.Status) string {
+		switch st {
+		case gig.StatusOpen:
+			return "Open"
+		case gig.StatusInProgress:
+			return "In Progress"
+		case gig.StatusBlocked:
+			return "Blocked"
+		case gig.StatusDeferred:
+			return "Deferred"
+		case gig.StatusClosed:
+			return "Closed"
+		default:
+			return string(st)
+		}
+	},
+	"columnColor": func(st gig.Status) string {
+		switch st {
+		case gig.StatusOpen:
+			return "#6b7280"
+		case gig.StatusInProgress:
+			return "#3b82f6"
+		case gig.StatusBlocked:
+			return "#ef4444"
+		case gig.StatusDeferred:
+			return "#f59e0b"
+		case gig.StatusClosed:
+			return "#22c55e"
+		default:
+			return "#6b7280"
+		}
+	},
+}
+
+func (s *Server) parseTemplates() {
+	s.tmpl = template.Must(
+		template.New("").Funcs(funcMap).ParseFS(templateFS, "templates/*.html", "templates/partials/*.html"),
+	)
+}
+
+func (s *Server) setupRoutes() {
+	s.mux = http.NewServeMux()
+	s.mux.HandleFunc("GET /", s.handleBoard)
+	s.mux.HandleFunc("GET /task/{id}", s.handleDetail)
+	s.mux.HandleFunc("GET /new", s.handleCreateForm)
+	s.mux.HandleFunc("POST /new", s.handleCreate)
+	s.mux.HandleFunc("POST /task/{id}/status", s.handleStatusChange)
+	s.mux.HandleFunc("POST /task/{id}/comment", s.handleAddComment)
+	s.mux.HandleFunc("POST /task/{id}/close", s.handleClose)
+	s.mux.HandleFunc("POST /task/{id}/reopen", s.handleReopen)
+	s.mux.HandleFunc("GET /task/{id}/edit", s.handleEditForm)
+	s.mux.HandleFunc("POST /task/{id}/edit", s.handleEdit)
+	s.mux.HandleFunc("GET /static/style.css", s.handleCSS)
+}
+
+func (s *Server) handleCSS(w http.ResponseWriter, r *http.Request) {
+	data, err := templateFS.ReadFile("templates/static/style.css")
+	if err != nil {
+		http.Error(w, "CSS not found", 404)
+		return
+	}
+	w.Header().Set("Content-Type", "text/css")
+	w.Write(data)
+}
+
+var allStatuses = []gig.Status{
+	gig.StatusOpen, gig.StatusInProgress, gig.StatusBlocked,
+	gig.StatusDeferred, gig.StatusClosed,
+}
+
+func (s *Server) handleBoard(w http.ResponseWriter, r *http.Request) {
+	view := r.URL.Query().Get("view")
+	if view == "" {
+		view = "top"
+	}
+	topOnly := view == "top"
+
+	var columns []Column
+	total := 0
+	for _, st := range allStatuses {
+		status := st
+		tasks, _ := s.store.List(gig.ListParams{Status: &status})
+		if topOnly {
+			var filtered []*gig.Task
+			for _, t := range tasks {
+				if t.ParentID == "" {
+					filtered = append(filtered, t)
+				}
+			}
+			tasks = filtered
+		}
+		columns = append(columns, Column{Status: st, Tasks: tasks})
+		total += len(tasks)
+	}
+
+	ready, _ := s.store.Ready()
+
+	data := BoardData{
+		Columns:    columns,
+		ReadyCount: len(ready),
+		TotalCount: total,
+		View:       view,
+	}
+
+	w.Header().Set("Content-Type", "text/html")
+	s.tmpl.ExecuteTemplate(w, "board.html", data)
+}
+
+func (s *Server) handleDetail(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	task, err := s.store.Get(id)
+	if err != nil {
+		http.Error(w, "Task not found", 404)
+		return
+	}
+
+	comments, _ := s.store.ListComments(id)
+	deps, _ := s.store.ListDependencies(id)
+	dependents, _ := s.store.ListDependents(id)
+	children, _ := s.store.Children(id)
+	events, _ := s.store.Events(id)
+
+	var depsOn []*DepInfo
+	for _, d := range deps {
+		t, err := s.store.Get(d.ToID)
+		if err == nil {
+			depsOn = append(depsOn, &DepInfo{Task: t, Dep: d})
+		}
+	}
+
+	var blocks []*DepInfo
+	for _, d := range dependents {
+		t, err := s.store.Get(d.FromID)
+		if err == nil {
+			blocks = append(blocks, &DepInfo{Task: t, Dep: d})
+		}
+	}
+
+	var childColumns []Column
+	if len(children) > 0 {
+		grouped := map[gig.Status][]*gig.Task{}
+		for _, c := range children {
+			grouped[c.Status] = append(grouped[c.Status], c)
+		}
+		for _, st := range allStatuses {
+			if tasks, ok := grouped[st]; ok {
+				childColumns = append(childColumns, Column{Status: st, Tasks: tasks})
+			}
+		}
+	}
+
+	data := DetailData{
+		Task:            task,
+		Comments:        comments,
+		DepsOn:          depsOn,
+		Blocks:          blocks,
+		Children:        children,
+		ChildrenColumns: childColumns,
+		Events:          events,
+	}
+
+	w.Header().Set("Content-Type", "text/html")
+	s.tmpl.ExecuteTemplate(w, "detail.html", data)
+}
+
+func (s *Server) handleCreateForm(w http.ResponseWriter, r *http.Request) {
+	allTasks, _ := s.store.List(gig.ListParams{})
+	data := DetailData{AllTasks: allTasks}
+	w.Header().Set("Content-Type", "text/html")
+	s.tmpl.ExecuteTemplate(w, "create.html", data)
+}
+
+func parsePriority(val string) gig.Priority {
+	switch val {
+	case "0":
+		return gig.P0
+	case "1":
+		return gig.P1
+	case "3":
+		return gig.P3
+	case "4":
+		return gig.P4
+	default:
+		return gig.P2
+	}
+}
+
+func (s *Server) handleCreate(w http.ResponseWriter, r *http.Request) {
+	r.ParseForm()
+
+	var labels []string
+	if l := r.FormValue("labels"); l != "" {
+		labels = strings.Split(l, ",")
+		for i := range labels {
+			labels[i] = strings.TrimSpace(labels[i])
+		}
+	}
+
+	_, err := s.store.Create(gig.CreateParams{
+		Title:       r.FormValue("title"),
+		Description: r.FormValue("description"),
+		Type:        gig.TaskType(r.FormValue("type")),
+		Priority:    parsePriority(r.FormValue("priority")),
+		ParentID:    r.FormValue("parent"),
+		Assignee:    r.FormValue("assignee"),
+		Labels:      labels,
+		Notes:       r.FormValue("notes"),
+		CreatedBy:   "web",
+	})
+	if err != nil {
+		http.Error(w, err.Error(), 400)
+		return
+	}
+
+	http.Redirect(w, r, "/", http.StatusSeeOther)
+}
+
+func (s *Server) handleStatusChange(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	r.ParseForm()
+	newStatus := gig.Status(r.FormValue("status"))
+
+	if err := s.store.UpdateStatus(id, newStatus, "web"); err != nil {
+		http.Error(w, err.Error(), 400)
+		return
+	}
+
+	if r.Header.Get("HX-Request") == "true" {
+		w.Header().Set("HX-Redirect", "/task/"+id)
+		w.WriteHeader(200)
+		return
+	}
+	http.Redirect(w, r, "/task/"+id, http.StatusSeeOther)
+}
+
+func (s *Server) handleAddComment(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	r.ParseForm()
+
+	author := r.FormValue("author")
+	if author == "" {
+		author = "web"
+	}
+
+	_, err := s.store.AddComment(id, author, r.FormValue("content"))
+	if err != nil {
+		http.Error(w, err.Error(), 400)
+		return
+	}
+
+	if r.Header.Get("HX-Request") == "true" {
+		comments, _ := s.store.ListComments(id)
+		s.tmpl.ExecuteTemplate(w, "comments.html", comments)
+		return
+	}
+	http.Redirect(w, r, "/task/"+id, http.StatusSeeOther)
+}
+
+func (s *Server) handleClose(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	r.ParseForm()
+	reason := r.FormValue("reason")
+
+	if err := s.store.CloseTask(id, reason, "web"); err != nil {
+		http.Error(w, err.Error(), 400)
+		return
+	}
+
+	if r.Header.Get("HX-Request") == "true" {
+		w.Header().Set("HX-Redirect", "/task/"+id)
+		w.WriteHeader(200)
+		return
+	}
+	http.Redirect(w, r, "/task/"+id, http.StatusSeeOther)
+}
+
+func (s *Server) handleReopen(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+
+	if err := s.store.Reopen(id, "web"); err != nil {
+		http.Error(w, err.Error(), 400)
+		return
+	}
+
+	if r.Header.Get("HX-Request") == "true" {
+		w.Header().Set("HX-Redirect", "/task/"+id)
+		w.WriteHeader(200)
+		return
+	}
+	http.Redirect(w, r, "/task/"+id, http.StatusSeeOther)
+}
+
+func (s *Server) handleEditForm(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	task, err := s.store.Get(id)
+	if err != nil {
+		http.Error(w, "Task not found", 404)
+		return
+	}
+
+	allTasks, _ := s.store.List(gig.ListParams{})
+	data := DetailData{Task: task, AllTasks: allTasks}
+	w.Header().Set("Content-Type", "text/html")
+	s.tmpl.ExecuteTemplate(w, "edit.html", data)
+}
+
+func (s *Server) handleEdit(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	r.ParseForm()
+
+	title := r.FormValue("title")
+	desc := r.FormValue("description")
+	assignee := r.FormValue("assignee")
+	notes := r.FormValue("notes")
+	priority := parsePriority(r.FormValue("priority"))
+
+	var labels *[]string
+	if l := r.FormValue("labels"); l != "" {
+		parts := strings.Split(l, ",")
+		for i := range parts {
+			parts[i] = strings.TrimSpace(parts[i])
+		}
+		labels = &parts
+	}
+
+	_, err := s.store.Update(id, gig.UpdateParams{
+		Title:       &title,
+		Description: &desc,
+		Priority:    &priority,
+		Assignee:    &assignee,
+		Notes:       &notes,
+		Labels:      labels,
+	}, "web")
+	if err != nil {
+		http.Error(w, err.Error(), 400)
+		return
+	}
+
+	http.Redirect(w, r, "/task/"+id, http.StatusSeeOther)
+}

--- a/ui/templates/board.html
+++ b/ui/templates/board.html
@@ -1,0 +1,72 @@
+{{define "board.html"}}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>gig controller</title>
+    <link rel="stylesheet" href="/static/style.css">
+    <script src="https://unpkg.com/htmx.org@2.0.4"></script>
+</head>
+<body>
+    <nav class="navbar">
+        <div class="nav-left">
+            <a href="/" class="logo">gig</a>
+            <span class="nav-stats">{{.TotalCount}} tasks &middot; {{.ReadyCount}} ready</span>
+        </div>
+        <div class="nav-right">
+            <div class="view-toggle">
+                <a href="/?view=top" class="btn btn-toggle {{if eq .View "top"}}btn-toggle-active{{end}}">Top-Level</a>
+                <a href="/?view=all" class="btn btn-toggle {{if eq .View "all"}}btn-toggle-active{{end}}">All Tasks</a>
+            </div>
+            <a href="/new" class="btn btn-primary">+ New Task</a>
+        </div>
+    </nav>
+
+    <div class="board" id="board">
+        {{range .Columns}}
+        <div class="column" data-status="{{.Status}}"
+             ondragover="event.preventDefault(); this.classList.add('column-dragover');"
+             ondragleave="this.classList.remove('column-dragover');"
+             ondrop="dropCard(event, this);">
+            <div class="column-header" style="border-top: 3px solid {{columnColor .Status}}">
+                <span class="column-title">
+                    <span class="column-dot" style="background: {{columnColor .Status}}"></span>
+                    {{statusLabel .Status}}
+                </span>
+                <span class="column-count badge-status-{{.Status}}">{{len .Tasks}}</span>
+            </div>
+            <div class="column-body"
+                 ondragover="event.preventDefault();"
+                 ondrop="dropCard(event, this.closest('.column'));">
+                {{range .Tasks}}
+                {{template "card.html" .}}
+                {{end}}
+                {{if not .Tasks}}
+                <div class="empty-column">No tasks</div>
+                {{end}}
+            </div>
+        </div>
+        {{end}}
+    </div>
+
+    <script>
+    function dropCard(event, column) {
+        event.preventDefault();
+        column.classList.remove('column-dragover');
+        var taskId = event.dataTransfer.getData('text/plain');
+        var newStatus = column.dataset.status;
+        if (!taskId || !newStatus) return;
+
+        fetch('/task/' + taskId + '/status', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+            body: 'status=' + encodeURIComponent(newStatus)
+        }).then(function() {
+            window.location.reload();
+        });
+    }
+    </script>
+</body>
+</html>
+{{end}}

--- a/ui/templates/create.html
+++ b/ui/templates/create.html
@@ -1,0 +1,92 @@
+{{define "create.html"}}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>New Task — gig</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+    <nav class="navbar">
+        <div class="nav-left">
+            <a href="/" class="logo">gig</a>
+            <span class="nav-breadcrumb">
+                <a href="/">Board</a> / New Task
+            </span>
+        </div>
+    </nav>
+
+    <div class="form-container">
+        <h2>Create Task</h2>
+        <form method="POST" action="/new" class="task-form">
+            <div class="form-group">
+                <label for="title">Title *</label>
+                <input type="text" id="title" name="title" class="input" required autofocus>
+            </div>
+
+            <div class="form-group">
+                <label for="description">Description</label>
+                <textarea id="description" name="description" class="input textarea" rows="3"></textarea>
+            </div>
+
+            <div class="form-row">
+                <div class="form-group">
+                    <label for="type">Type</label>
+                    <select id="type" name="type" class="input">
+                        <option value="task">Task</option>
+                        <option value="bug">Bug</option>
+                        <option value="feature">Feature</option>
+                        <option value="epic">Epic</option>
+                        <option value="chore">Chore</option>
+                    </select>
+                </div>
+
+                <div class="form-group">
+                    <label for="priority">Priority</label>
+                    <select id="priority" name="priority" class="input">
+                        <option value="0">P0 — Critical</option>
+                        <option value="1">P1 — High</option>
+                        <option value="2" selected>P2 — Medium</option>
+                        <option value="3">P3 — Low</option>
+                        <option value="4">P4 — Backlog</option>
+                    </select>
+                </div>
+            </div>
+
+            <div class="form-row">
+                <div class="form-group">
+                    <label for="assignee">Assignee</label>
+                    <input type="text" id="assignee" name="assignee" class="input" placeholder="e.g. neeraj">
+                </div>
+
+                <div class="form-group">
+                    <label for="parent">Parent Task</label>
+                    <select id="parent" name="parent" class="input">
+                        <option value="">None</option>
+                        {{range .AllTasks}}
+                        <option value="{{.ID}}">{{.ID}} — {{.Title}}</option>
+                        {{end}}
+                    </select>
+                </div>
+            </div>
+
+            <div class="form-group">
+                <label for="labels">Labels</label>
+                <input type="text" id="labels" name="labels" class="input" placeholder="comma-separated: backend, urgent">
+            </div>
+
+            <div class="form-group">
+                <label for="notes">Notes</label>
+                <textarea id="notes" name="notes" class="input textarea" rows="2"></textarea>
+            </div>
+
+            <div class="form-actions">
+                <a href="/" class="btn btn-secondary">Cancel</a>
+                <button type="submit" class="btn btn-primary">Create Task</button>
+            </div>
+        </form>
+    </div>
+</body>
+</html>
+{{end}}

--- a/ui/templates/detail.html
+++ b/ui/templates/detail.html
@@ -1,0 +1,202 @@
+{{define "detail.html"}}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{.Task.Title}} — gig</title>
+    <link rel="stylesheet" href="/static/style.css">
+    <script src="https://unpkg.com/htmx.org@2.0.4"></script>
+</head>
+<body>
+    <nav class="navbar">
+        <div class="nav-left">
+            <a href="/" class="logo">gig</a>
+            <span class="nav-breadcrumb">
+                <a href="/">Board</a> / {{.Task.ID}}
+            </span>
+        </div>
+        <div class="nav-right">
+            <a href="/task/{{.Task.ID}}/edit" class="btn btn-secondary">Edit</a>
+        </div>
+    </nav>
+
+    <div class="detail-layout">
+        <div class="detail-main">
+            <div class="detail-header">
+                <h1>{{.Task.Title}}</h1>
+                <div class="detail-badges">
+                    <span class="badge {{priorityClass .Task.Priority}}">{{priorityLabel .Task.Priority}}</span>
+                    <span class="badge badge-type">{{.Task.Type}}</span>
+                    <span class="badge badge-status badge-status-{{.Task.Status}}">
+                        {{statusIcon .Task.Status}} {{statusLabel .Task.Status}}
+                    </span>
+                </div>
+            </div>
+
+            {{if .Task.Description}}
+            <div class="detail-section">
+                <h3>Description</h3>
+                <p>{{.Task.Description}}</p>
+            </div>
+            {{end}}
+
+            {{if .Task.Notes}}
+            <div class="detail-section">
+                <h3>Notes</h3>
+                <p>{{.Task.Notes}}</p>
+            </div>
+            {{end}}
+
+            <!-- Children (subtasks) — mini kanban -->
+            {{if .Children}}
+            <div class="detail-section">
+                <h3>Subtasks ({{len .Children}})</h3>
+                <div class="mini-board">
+                    {{range .ChildrenColumns}}
+                    <div class="mini-column" data-status="{{.Status}}"
+                         ondragover="event.preventDefault(); this.classList.add('column-dragover');"
+                         ondragleave="this.classList.remove('column-dragover');"
+                         ondrop="dropCard(event, this);">
+                        <div class="mini-column-header" style="border-top: 2px solid {{columnColor .Status}}">
+                            <span class="mini-column-title">{{statusLabel .Status}}</span>
+                            <span class="column-count badge-status-{{.Status}}">{{len .Tasks}}</span>
+                        </div>
+                        <div class="mini-column-body"
+                             ondragover="event.preventDefault();"
+                             ondrop="dropCard(event, this.closest('.mini-column'));">
+                            {{range .Tasks}}
+                            {{template "card.html" .}}
+                            {{end}}
+                        </div>
+                    </div>
+                    {{end}}
+                </div>
+            </div>
+            <script>
+            function dropCard(event, column) {
+                event.preventDefault();
+                column.classList.remove('column-dragover');
+                var taskId = event.dataTransfer.getData('text/plain');
+                var newStatus = column.dataset.status;
+                if (!taskId || !newStatus) return;
+
+                fetch('/task/' + taskId + '/status', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+                    body: 'status=' + encodeURIComponent(newStatus)
+                }).then(function() {
+                    window.location.reload();
+                });
+            }
+            </script>
+            {{end}}
+
+            <!-- Comments -->
+            <div class="detail-section">
+                <h3>Comments</h3>
+                {{template "comments.html" .Comments}}
+
+                <form class="comment-form" hx-post="/task/{{.Task.ID}}/comment" hx-target="#comments-list" hx-swap="outerHTML">
+                    <input type="text" name="author" placeholder="Your name" class="input input-sm">
+                    <div class="comment-form-row">
+                        <input type="text" name="content" placeholder="Add a comment..." class="input" required>
+                        <button type="submit" class="btn btn-primary">Send</button>
+                    </div>
+                </form>
+            </div>
+
+            <!-- Events -->
+            {{if .Events}}
+            <div class="detail-section">
+                <h3>Activity</h3>
+                <div class="events-list">
+                    {{range .Events}}
+                    <div class="event-item">
+                        <span class="event-time">{{.Timestamp.Format "Jan 2, 15:04"}}</span>
+                        <span class="event-type">{{.Type}}</span>
+                        {{if .Field}}
+                        <span class="muted">{{.Field}}: {{.OldValue}} → {{.NewValue}}</span>
+                        {{end}}
+                        {{if .Actor}}<span class="muted">by {{.Actor}}</span>{{end}}
+                    </div>
+                    {{end}}
+                </div>
+            </div>
+            {{end}}
+        </div>
+
+        <div class="detail-sidebar">
+            <!-- Meta info -->
+            <div class="sidebar-section">
+                <h4>Details</h4>
+                <dl class="meta-list">
+                    <dt>ID</dt><dd>{{.Task.ID}}</dd>
+                    <dt>Status</dt><dd>{{statusLabel .Task.Status}}</dd>
+                    <dt>Priority</dt><dd>{{.Task.Priority}}</dd>
+                    <dt>Type</dt><dd>{{.Task.Type}}</dd>
+                    {{if .Task.Assignee}}<dt>Assignee</dt><dd>@{{.Task.Assignee}}</dd>{{end}}
+                    {{if .Task.ParentID}}<dt>Parent</dt><dd><a href="/task/{{.Task.ParentID}}">{{.Task.ParentID}}</a></dd>{{end}}
+                    {{if .Task.Labels}}<dt>Labels</dt><dd>{{range .Task.Labels}}<span class="label">{{.}}</span> {{end}}</dd>{{end}}
+                    <dt>Created</dt><dd>{{.Task.CreatedAt.Format "Jan 2, 2006 15:04"}}</dd>
+                    <dt>Updated</dt><dd>{{.Task.UpdatedAt.Format "Jan 2, 2006 15:04"}}</dd>
+                    {{if .Task.ClosedAt}}<dt>Closed</dt><dd>{{.Task.ClosedAt.Format "Jan 2, 2006 15:04"}}</dd>{{end}}
+                    {{if .Task.CloseReason}}<dt>Reason</dt><dd>{{.Task.CloseReason}}</dd>{{end}}
+                </dl>
+            </div>
+
+            <!-- Actions -->
+            <div class="sidebar-section">
+                <h4>Actions</h4>
+
+                {{if ne .Task.Status "closed"}}
+                <form hx-post="/task/{{.Task.ID}}/status" hx-target="body" class="action-form">
+                    <label>Change Status</label>
+                    <select name="status" onchange="this.form.requestSubmit()">
+                        <option value="">-- select --</option>
+                        <option value="open">Open</option>
+                        <option value="in_progress">In Progress</option>
+                        <option value="blocked">Blocked</option>
+                        <option value="deferred">Deferred</option>
+                    </select>
+                </form>
+
+                <form hx-post="/task/{{.Task.ID}}/close" hx-target="body" class="action-form">
+                    <button type="submit" class="btn btn-danger btn-full">Close Task</button>
+                </form>
+                {{else}}
+                <form hx-post="/task/{{.Task.ID}}/reopen" hx-target="body" class="action-form">
+                    <button type="submit" class="btn btn-secondary btn-full">Reopen Task</button>
+                </form>
+                {{end}}
+            </div>
+
+            <!-- Dependencies -->
+            {{if .DepsOn}}
+            <div class="sidebar-section">
+                <h4>Depends On</h4>
+                {{range .DepsOn}}
+                <a href="/task/{{.Task.ID}}" class="dep-link">
+                    <span style="color: {{columnColor .Task.Status}}">{{statusIcon .Task.Status}}</span>
+                    {{.Task.Title}}
+                </a>
+                {{end}}
+            </div>
+            {{end}}
+
+            {{if .Blocks}}
+            <div class="sidebar-section">
+                <h4>Blocks</h4>
+                {{range .Blocks}}
+                <a href="/task/{{.Task.ID}}" class="dep-link">
+                    <span style="color: {{columnColor .Task.Status}}">{{statusIcon .Task.Status}}</span>
+                    {{.Task.Title}}
+                </a>
+                {{end}}
+            </div>
+            {{end}}
+        </div>
+    </div>
+</body>
+</html>
+{{end}}

--- a/ui/templates/edit.html
+++ b/ui/templates/edit.html
@@ -1,0 +1,69 @@
+{{define "edit.html"}}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Edit {{.Task.Title}} — gig</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+    <nav class="navbar">
+        <div class="nav-left">
+            <a href="/" class="logo">gig</a>
+            <span class="nav-breadcrumb">
+                <a href="/">Board</a> / <a href="/task/{{.Task.ID}}">{{.Task.ID}}</a> / Edit
+            </span>
+        </div>
+    </nav>
+
+    <div class="form-container">
+        <h2>Edit Task</h2>
+        <form method="POST" action="/task/{{.Task.ID}}/edit" class="task-form">
+            <div class="form-group">
+                <label for="title">Title</label>
+                <input type="text" id="title" name="title" class="input" value="{{.Task.Title}}" required>
+            </div>
+
+            <div class="form-group">
+                <label for="description">Description</label>
+                <textarea id="description" name="description" class="input textarea" rows="3">{{.Task.Description}}</textarea>
+            </div>
+
+            <div class="form-row">
+                <div class="form-group">
+                    <label for="priority">Priority</label>
+                    <select id="priority" name="priority" class="input">
+                        <option value="0" {{if eq .Task.Priority 0}}selected{{end}}>P0 — Critical</option>
+                        <option value="1" {{if eq .Task.Priority 1}}selected{{end}}>P1 — High</option>
+                        <option value="2" {{if eq .Task.Priority 2}}selected{{end}}>P2 — Medium</option>
+                        <option value="3" {{if eq .Task.Priority 3}}selected{{end}}>P3 — Low</option>
+                        <option value="4" {{if eq .Task.Priority 4}}selected{{end}}>P4 — Backlog</option>
+                    </select>
+                </div>
+
+                <div class="form-group">
+                    <label for="assignee">Assignee</label>
+                    <input type="text" id="assignee" name="assignee" class="input" value="{{.Task.Assignee}}">
+                </div>
+            </div>
+
+            <div class="form-group">
+                <label for="labels">Labels</label>
+                <input type="text" id="labels" name="labels" class="input" value="{{range $i, $l := .Task.Labels}}{{if $i}}, {{end}}{{$l}}{{end}}">
+            </div>
+
+            <div class="form-group">
+                <label for="notes">Notes</label>
+                <textarea id="notes" name="notes" class="input textarea" rows="3">{{.Task.Notes}}</textarea>
+            </div>
+
+            <div class="form-actions">
+                <a href="/task/{{.Task.ID}}" class="btn btn-secondary">Cancel</a>
+                <button type="submit" class="btn btn-primary">Save Changes</button>
+            </div>
+        </form>
+    </div>
+</body>
+</html>
+{{end}}

--- a/ui/templates/partials/card.html
+++ b/ui/templates/partials/card.html
@@ -1,0 +1,15 @@
+{{define "card.html"}}
+<a href="/task/{{.ID}}" class="card status-{{.Status}}" draggable="true" data-task-id="{{.ID}}"
+   ondragstart="event.dataTransfer.setData('text/plain', this.dataset.taskId); this.classList.add('dragging');"
+   ondragend="this.classList.remove('dragging');">
+    <div class="card-header">
+        <span class="badge {{priorityClass .Priority}}">{{priorityLabel .Priority}}</span>
+        <span class="card-type">{{.Type}}</span>
+    </div>
+    <div class="card-title">{{.Title}}</div>
+    <div class="card-footer">
+        <span class="card-id">{{.ID}}</span>
+        {{if .Assignee}}<span class="card-assignee">@{{.Assignee}}</span>{{end}}
+    </div>
+</a>
+{{end}}

--- a/ui/templates/partials/comments.html
+++ b/ui/templates/partials/comments.html
@@ -1,0 +1,16 @@
+{{define "comments.html"}}
+<div class="comments-list" id="comments-list">
+    {{range .}}
+    <div class="comment">
+        <div class="comment-meta">
+            <strong>{{if .Author}}{{.Author}}{{else}}anonymous{{end}}</strong>
+            <span class="comment-time">{{.CreatedAt.Format "Jan 2, 15:04"}}</span>
+        </div>
+        <div class="comment-body">{{.Content}}</div>
+    </div>
+    {{end}}
+    {{if not .}}
+    <p class="muted">No comments yet.</p>
+    {{end}}
+</div>
+{{end}}

--- a/ui/templates/static/style.css
+++ b/ui/templates/static/style.css
@@ -1,0 +1,412 @@
+/* Reset & Base */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+    --bg: #0d1117;
+    --bg-surface: #161b22;
+    --bg-card: #1c2128;
+    --bg-hover: #252b33;
+    --border: #30363d;
+    --text: #e6edf3;
+    --text-muted: #7d8590;
+    --accent: #58a6ff;
+    --danger: #f85149;
+    --success: #3fb950;
+    --warning: #d29922;
+    --radius: 8px;
+    --font: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+
+    /* Status colors */
+    --status-open: #8b949e;
+    --status-open-bg: #8b949e18;
+    --status-in-progress: #58a6ff;
+    --status-in-progress-bg: #58a6ff18;
+    --status-blocked: #f85149;
+    --status-blocked-bg: #f8514918;
+    --status-deferred: #d29922;
+    --status-deferred-bg: #d2992218;
+    --status-closed: #3fb950;
+    --status-closed-bg: #3fb95018;
+}
+
+body {
+    font-family: var(--font);
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.5;
+    min-height: 100vh;
+}
+
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+/* Navbar */
+.navbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 12px 24px;
+    background: var(--bg-surface);
+    border-bottom: 1px solid var(--border);
+    position: sticky;
+    top: 0;
+    z-index: 10;
+}
+
+.nav-left { display: flex; align-items: center; gap: 16px; }
+.nav-right { display: flex; align-items: center; gap: 8px; }
+
+.logo {
+    font-size: 20px;
+    font-weight: 700;
+    color: var(--text);
+    letter-spacing: -0.5px;
+}
+.logo:hover { text-decoration: none; color: var(--accent); }
+
+.nav-stats { color: var(--text-muted); font-size: 13px; }
+.nav-breadcrumb { color: var(--text-muted); font-size: 14px; }
+.nav-breadcrumb a { color: var(--text-muted); }
+.nav-breadcrumb a:hover { color: var(--accent); }
+
+/* Buttons */
+.btn {
+    display: inline-flex;
+    align-items: center;
+    padding: 6px 14px;
+    border-radius: 6px;
+    font-size: 13px;
+    font-weight: 500;
+    border: 1px solid var(--border);
+    cursor: pointer;
+    background: var(--bg-card);
+    color: var(--text);
+    text-decoration: none;
+    transition: background 0.15s;
+}
+.btn:hover { background: var(--bg-hover); text-decoration: none; }
+.btn-primary { background: #238636; border-color: #2ea043; color: #fff; }
+.btn-primary:hover { background: #2ea043; }
+.btn-danger { background: #da3633; border-color: #f85149; color: #fff; }
+.btn-danger:hover { background: #f85149; }
+.btn-secondary { background: var(--bg-surface); }
+.btn-full { width: 100%; justify-content: center; }
+
+/* Board */
+.board {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 12px;
+    padding: 20px 24px;
+    min-height: calc(100vh - 56px);
+    align-items: start;
+}
+
+.column {
+    background: var(--bg-surface);
+    border-radius: var(--radius);
+    border: 1px solid var(--border);
+    min-height: 200px;
+}
+
+.column-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 12px 14px;
+    border-bottom: 1px solid var(--border);
+    border-radius: var(--radius) var(--radius) 0 0;
+}
+
+.column-title {
+    font-size: 13px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+.column-title .column-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    display: inline-block;
+}
+.column-count {
+    padding: 2px 8px;
+    border-radius: 12px;
+    font-size: 12px;
+    font-weight: 600;
+}
+
+.column-body { padding: 8px; display: flex; flex-direction: column; gap: 6px; }
+
+.empty-column { color: var(--text-muted); font-size: 13px; text-align: center; padding: 24px 8px; }
+
+/* Cards */
+.card {
+    display: block;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-left: 3px solid var(--border);
+    border-radius: 6px;
+    padding: 10px 12px;
+    cursor: pointer;
+    transition: border-color 0.15s, background 0.15s;
+    text-decoration: none;
+    color: var(--text);
+}
+.card:hover { border-color: var(--accent); border-left-color: var(--accent); background: var(--bg-hover); text-decoration: none; cursor: grab; }
+.card.dragging { opacity: 0.4; }
+.column-dragover, .mini-column.column-dragover { background: var(--bg-hover); outline: 2px dashed var(--accent); outline-offset: -2px; }
+
+.card.status-open { border-left-color: var(--status-open); }
+.card.status-in_progress { border-left-color: var(--status-in-progress); background: var(--status-in-progress-bg); }
+.card.status-blocked { border-left-color: var(--status-blocked); background: var(--status-blocked-bg); }
+.card.status-deferred { border-left-color: var(--status-deferred); background: var(--status-deferred-bg); }
+.card.status-closed { border-left-color: var(--status-closed); opacity: 0.7; }
+
+.card-header { display: flex; align-items: center; gap: 6px; margin-bottom: 4px; }
+.card-title { font-size: 13px; font-weight: 500; line-height: 1.4; }
+.card-footer { display: flex; justify-content: space-between; align-items: center; margin-top: 6px; }
+.card-id { font-size: 11px; color: var(--text-muted); font-family: monospace; }
+.card-assignee { font-size: 11px; color: var(--accent); }
+.card-type { font-size: 11px; color: var(--text-muted); }
+.card-status-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    display: inline-block;
+    flex-shrink: 0;
+}
+
+/* Badges */
+.badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 1px 6px;
+    border-radius: 4px;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+}
+
+.priority-critical { background: #f8514922; color: #f85149; }
+.priority-high { background: #d2992222; color: #d29922; }
+.priority-medium { background: #58a6ff22; color: #58a6ff; }
+.priority-low { background: #3fb95022; color: #3fb950; }
+.priority-backlog { background: #7d859022; color: #7d8590; }
+
+.badge-type { background: var(--bg-surface); color: var(--text-muted); }
+.badge-status { border: 1px solid; background: transparent; }
+.badge-status-open { border-color: var(--status-open); color: var(--status-open); background: var(--status-open-bg); }
+.badge-status-in_progress { border-color: var(--status-in-progress); color: var(--status-in-progress); background: var(--status-in-progress-bg); }
+.badge-status-blocked { border-color: var(--status-blocked); color: var(--status-blocked); background: var(--status-blocked-bg); }
+.badge-status-deferred { border-color: var(--status-deferred); color: var(--status-deferred); background: var(--status-deferred-bg); }
+.badge-status-closed { border-color: var(--status-closed); color: var(--status-closed); background: var(--status-closed-bg); }
+
+.label {
+    display: inline-block;
+    padding: 1px 6px;
+    border-radius: 12px;
+    font-size: 11px;
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    color: var(--text-muted);
+    margin-right: 4px;
+}
+
+/* Detail Layout */
+.detail-layout {
+    display: grid;
+    grid-template-columns: 1fr 300px;
+    gap: 24px;
+    padding: 24px;
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+.detail-header { margin-bottom: 20px; }
+.detail-header h1 { font-size: 24px; font-weight: 600; margin-bottom: 8px; }
+.detail-badges { display: flex; gap: 8px; flex-wrap: wrap; }
+
+.detail-section {
+    margin-bottom: 24px;
+    padding-bottom: 24px;
+    border-bottom: 1px solid var(--border);
+}
+.detail-section h3 {
+    font-size: 14px;
+    font-weight: 600;
+    margin-bottom: 10px;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+}
+.detail-section p { font-size: 14px; color: var(--text); }
+
+/* Sidebar */
+.detail-sidebar {
+    position: sticky;
+    top: 80px;
+    align-self: start;
+}
+
+.sidebar-section {
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 14px;
+    margin-bottom: 12px;
+}
+
+.sidebar-section h4 {
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--text-muted);
+    margin-bottom: 10px;
+}
+
+.meta-list { display: grid; grid-template-columns: 80px 1fr; gap: 4px 8px; font-size: 13px; }
+.meta-list dt { color: var(--text-muted); }
+.meta-list dd { color: var(--text); }
+
+.dep-link {
+    display: block;
+    font-size: 13px;
+    padding: 4px 0;
+    color: var(--text);
+}
+.dep-link:hover { color: var(--accent); }
+
+/* View Toggle */
+.view-toggle { display: flex; gap: 0; margin-right: 8px; }
+.btn-toggle {
+    padding: 5px 12px;
+    font-size: 12px;
+    border-radius: 0;
+    border: 1px solid var(--border);
+    background: var(--bg-card);
+    color: var(--text-muted);
+}
+.btn-toggle:first-child { border-radius: 6px 0 0 6px; }
+.btn-toggle:last-child { border-radius: 0 6px 6px 0; border-left: none; }
+.btn-toggle-active { background: var(--accent); color: #fff; border-color: var(--accent); }
+.btn-toggle:hover { text-decoration: none; }
+
+/* Mini Kanban (subtasks in detail view) */
+.mini-board {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 8px;
+}
+.mini-column {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    min-height: 80px;
+}
+.mini-column-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 8px 10px;
+    border-bottom: 1px solid var(--border);
+    border-radius: 6px 6px 0 0;
+}
+.mini-column-title {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--text-muted);
+}
+.mini-column-body {
+    padding: 6px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+/* Comments */
+.comment {
+    padding: 10px 0;
+    border-bottom: 1px solid var(--border);
+}
+.comment:last-child { border-bottom: none; }
+.comment-meta { font-size: 13px; margin-bottom: 4px; }
+.comment-meta strong { color: var(--text); }
+.comment-time { color: var(--text-muted); font-size: 12px; margin-left: 8px; }
+.comment-body { font-size: 14px; color: var(--text); }
+
+.comment-form { margin-top: 12px; }
+.comment-form-row { display: flex; gap: 8px; margin-top: 6px; }
+.comment-form-row .input { flex: 1; }
+
+/* Events */
+.events-list { font-size: 13px; }
+.event-item { padding: 4px 0; display: flex; gap: 8px; align-items: baseline; }
+.event-time { color: var(--text-muted); font-size: 12px; font-family: monospace; white-space: nowrap; }
+.event-type { font-weight: 500; }
+
+/* Forms */
+.form-container {
+    max-width: 640px;
+    margin: 32px auto;
+    padding: 0 24px;
+}
+.form-container h2 { font-size: 20px; margin-bottom: 20px; }
+
+.task-form { display: flex; flex-direction: column; gap: 16px; }
+.form-group { display: flex; flex-direction: column; gap: 4px; }
+.form-group label { font-size: 13px; font-weight: 500; color: var(--text-muted); }
+
+.form-row { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+
+.input {
+    padding: 8px 12px;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    color: var(--text);
+    font-size: 14px;
+    font-family: var(--font);
+}
+.input:focus { outline: none; border-color: var(--accent); }
+.input-sm { padding: 4px 8px; font-size: 12px; max-width: 160px; }
+.textarea { resize: vertical; }
+
+select.input { cursor: pointer; }
+
+.form-actions { display: flex; gap: 8px; justify-content: flex-end; padding-top: 8px; }
+
+.action-form { margin-bottom: 8px; }
+.action-form label { font-size: 12px; color: var(--text-muted); display: block; margin-bottom: 4px; }
+.action-form select {
+    width: 100%;
+    padding: 6px 8px;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    color: var(--text);
+    font-size: 13px;
+    cursor: pointer;
+}
+
+.muted { color: var(--text-muted); font-size: 13px; }
+
+/* Responsive */
+@media (max-width: 1024px) {
+    .board { grid-template-columns: repeat(3, 1fr); }
+    .detail-layout { grid-template-columns: 1fr; }
+    .detail-sidebar { position: static; }
+}
+
+@media (max-width: 640px) {
+    .board { grid-template-columns: 1fr; }
+    .form-row { grid-template-columns: 1fr; }
+}


### PR DESCRIPTION
## Summary
- **Custom attributes**: Two-layer system (schema registry + per-task typed key-value pairs) with string, boolean, and object (JSON) types. Full SDK + CLI (`gig attr define/set/get/list/delete`). List filter via `--attr key=value`.
- **Embedded web UI**: Kanban board with drag-and-drop, task detail view with subtask mini-kanban, top-level/all task filter. Available as `gig ui` CLI command or `ui.New(store)` SDK.
- **Subtask ID ladder notation**: Children get `parent.1`, `parent.2`, grandchildren get `parent.1.1` — hierarchy visible from the ID itself.
- **GitHub Actions CI**: Runs `go build` and `go test ./...` on PRs to main.

## Test plan
- [x] `go test ./...` passes (16 attribute tests, subtask ladder test, all existing tests)
- [ ] CI workflow runs successfully on this PR
- [ ] Manual: `gig attr define/set/get/list/delete` commands work
- [ ] Manual: `gig ui` serves kanban board with drag-and-drop

🤖 Generated with [Claude Code](https://claude.com/claude-code)