### PR TITLE
R11 Gig-Upgrades: CAS claim + ErrAlreadyClaimed, DSN pragmas, durable transactional events, ID collision retry + 6-char IDs, EventsAfterID cursor

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,8 +36,8 @@ jobs:
 
       - name: Run Tests
         run: |
-          go test ./... -count=1
-          go test -tags=e2e -count=1 ./cmd/gig/
+          go test ./... -race -count=1
+          go test -tags=e2e -race -count=1 ./cmd/gig/
 
       - name: Create or Update GitHub Release
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,11 @@ jobs:
       - name: Build
         run: go build ./...
 
+      - name: Vet
+        run: go vet ./...
+
       - name: Unit Tests
-        run: go test ./... -v -count=1
+        run: go test ./... -race -v -count=1
 
       - name: E2E CLI Tests
-        run: go test -tags=e2e -v -count=1 ./cmd/gig/
+        run: go test -tags=e2e -race -v -count=1 ./cmd/gig/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,52 @@
+# Changelog
+
+All notable changes to gig are documented here. This project follows
+[Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+
+- **`EventsAfterID(afterID int64, limit int)`** — event-stream cursor keyed on
+  the events table's monotonic integer primary key. Persist the last id you
+  processed and pass it back to resume with no missed or duplicated events.
+  Prefer this over `EventsSince` for reliable polling: RFC3339 timestamps have
+  only second precision, so a time cursor can miss or duplicate events sharing a
+  boundary second.
+- `-race` in CI (test and release workflows) plus a `go vet` step.
+
+### Changed
+
+- **`Claim` is now compare-and-swap (BREAKING semantics).** The claim is applied
+  with a conditional `UPDATE`, so two concurrent claimers can no longer both
+  succeed. Claiming a task already held by a **different** assignee now returns
+  the new sentinel **`ErrAlreadyClaimed`** (check with `errors.Is`). Re-claiming
+  by the **same** assignee still succeeds (idempotent resume). Terminal tasks
+  (closed/cancelled) return `ErrAlreadyClaimed`; `open`/`blocked`/`deferred`
+  remain claimable as before.
+- **Default generated-ID hash length 4 → 6** (`gig-a3f8` → `gig-a3f8c1`),
+  expanding the space from 65,536 to 16.7M values. Existing IDs stay valid —
+  length only affects newly generated IDs. Override with `WithHashLength`.
+- `Create` now retries on an ID collision (root tasks regenerate the random id;
+  subtasks bump the ladder offset) instead of surfacing a raw
+  `UNIQUE constraint failed` error; after the bounded retries it returns a clear
+  "id space exhausted" error.
+- `Events`, `EventsSince`, and `Events(taskID)` order by `(timestamp, id)` so
+  same-second batches are deterministic (insertion order).
+
+### Fixed
+
+- **Connection PRAGMAs now apply to every pooled connection.** `busy_timeout`,
+  `journal_mode=WAL`, and `foreign_keys` are set via the DSN's `_pragma` query
+  params instead of one-off `PRAGMA` execs that bound to a single pooled
+  connection — the previous approach left other connections with
+  `busy_timeout=0` (instant `SQLITE_BUSY` under contention) and foreign keys
+  off. `SetMaxOpenConns(1)` additionally serializes in-process access.
+- **Task mutations and their audit events are now transactional.** `Create`,
+  `Update`, `UpdateStatus`, `CloseTask`, `CancelTask`, and `Claim` write the row
+  change and its event in one transaction (event emission happens after commit),
+  so a crash or a failed event insert can no longer leave a mutation without its
+  audit record. `recordEvent` no longer silently discards insert errors.
+- **Concurrent subtask creation no longer mints duplicate ladder IDs.** The
+  child-count read and insert share the `Create` transaction, with a bounded
+  retry on collision.

--- a/checkpoint.go
+++ b/checkpoint.go
@@ -60,28 +60,36 @@ func (s *Store) ListCheckpoints(taskID string) ([]*Checkpoint, error) {
 	if err != nil {
 		return nil, fmt.Errorf("list checkpoints: %w", err)
 	}
-	defer rows.Close()
-
 	var cps []*Checkpoint
 	for rows.Next() {
 		var cp Checkpoint
 		var createdAt string
 		if err := rows.Scan(&cp.ID, &cp.TaskID, &cp.Author, &cp.Done, &cp.Decisions, &cp.Next, &cp.Blockers, &createdAt); err != nil {
+			rows.Close()
 			return nil, fmt.Errorf("scan checkpoint: %w", err)
 		}
 		if t := strToTime(createdAt); t != nil {
 			cp.CreatedAt = *t
 		}
+		cps = append(cps, &cp)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return nil, err
+	}
+	// Close the outer iterator before issuing per-checkpoint file queries: with
+	// SetMaxOpenConns(1) the open rows holds the only connection, so a nested
+	// query would deadlock. Fetch files after the cursor is fully drained.
+	rows.Close()
 
+	for _, cp := range cps {
 		files, err := s.checkpointFiles(cp.ID)
 		if err != nil {
 			return nil, err
 		}
 		cp.Files = files
-
-		cps = append(cps, &cp)
 	}
-	return cps, rows.Err()
+	return cps, nil
 }
 
 // LatestCheckpoint returns the most recent checkpoint for a task, or nil if none exist.

--- a/claim_cas_test.go
+++ b/claim_cas_test.go
@@ -1,0 +1,114 @@
+package gig
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// TestClaimConcurrent verifies the compare-and-swap: two goroutines racing to
+// claim the same open task result in exactly one winner; the loser gets
+// ErrAlreadyClaimed (finding #2 — previously both silently "won").
+func TestClaimConcurrent(t *testing.T) {
+	store, _ := tempDB(t)
+	task, _ := store.Create(CreateParams{Title: "Contended"})
+
+	var wins, claimed int64
+	var otherErr error
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+
+	for _, who := range []string{"agent-a", "agent-b"} {
+		wg.Add(1)
+		go func(assignee string) {
+			defer wg.Done()
+			<-start
+			_, err := store.Claim(task.ID, assignee)
+			switch {
+			case err == nil:
+				atomic.AddInt64(&wins, 1)
+			case errors.Is(err, ErrAlreadyClaimed):
+				atomic.AddInt64(&claimed, 1)
+			default:
+				otherErr = err
+			}
+		}(who)
+	}
+	close(start)
+	wg.Wait()
+
+	if otherErr != nil {
+		t.Fatalf("unexpected error: %v", otherErr)
+	}
+	if wins != 1 {
+		t.Errorf("expected exactly 1 winner, got %d", wins)
+	}
+	if claimed != 1 {
+		t.Errorf("expected exactly 1 ErrAlreadyClaimed, got %d", claimed)
+	}
+}
+
+// TestClaimSameAssigneeReclaim verifies idempotent resume: the same assignee
+// re-claiming an in_progress task succeeds.
+func TestClaimSameAssigneeReclaim(t *testing.T) {
+	store, _ := tempDB(t)
+	task, _ := store.Create(CreateParams{Title: "Resumable"})
+
+	if _, err := store.Claim(task.ID, "agent-1"); err != nil {
+		t.Fatalf("first claim: %v", err)
+	}
+	if _, err := store.Claim(task.ID, "agent-1"); err != nil {
+		t.Fatalf("same-assignee re-claim should succeed, got: %v", err)
+	}
+	got, _ := store.Get(task.ID)
+	if got.Assignee != "agent-1" || got.Status != StatusInProgress {
+		t.Errorf("after re-claim: assignee=%q status=%q", got.Assignee, got.Status)
+	}
+}
+
+// TestClaimDifferentAssigneeFails verifies a different assignee claiming an
+// already-claimed task gets ErrAlreadyClaimed and the original claim stands.
+func TestClaimDifferentAssigneeFails(t *testing.T) {
+	store, _ := tempDB(t)
+	task, _ := store.Create(CreateParams{Title: "Held"})
+
+	if _, err := store.Claim(task.ID, "agent-1"); err != nil {
+		t.Fatalf("first claim: %v", err)
+	}
+	_, err := store.Claim(task.ID, "agent-2")
+	if !errors.Is(err, ErrAlreadyClaimed) {
+		t.Fatalf("expected ErrAlreadyClaimed, got: %v", err)
+	}
+	got, _ := store.Get(task.ID)
+	if got.Assignee != "agent-1" {
+		t.Errorf("assignee should still be agent-1, got %q", got.Assignee)
+	}
+}
+
+// TestClaimTerminalFails verifies terminal tasks cannot be claimed.
+func TestClaimTerminalFails(t *testing.T) {
+	store, _ := tempDB(t)
+	task, _ := store.Create(CreateParams{Title: "Done"})
+	if err := store.CloseTask(task.ID, "finished", "actor"); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if _, err := store.Claim(task.ID, "agent-1"); !errors.Is(err, ErrAlreadyClaimed) {
+		t.Fatalf("expected ErrAlreadyClaimed for closed task, got: %v", err)
+	}
+}
+
+// TestClaimBlockedAndDeferred verifies non-terminal, non-in_progress statuses
+// (blocked, deferred) remain claimable — preserving prior behaviour.
+func TestClaimBlockedAndDeferred(t *testing.T) {
+	for _, st := range []Status{StatusBlocked, StatusDeferred} {
+		store, _ := tempDB(t)
+		task, _ := store.Create(CreateParams{Title: "Task"})
+		if err := store.UpdateStatus(task.ID, st, "actor"); err != nil {
+			t.Fatalf("set %s: %v", st, err)
+		}
+		if _, err := store.Claim(task.ID, "agent-1"); err != nil {
+			t.Errorf("claiming %s task should succeed, got: %v", st, err)
+		}
+	}
+}

--- a/concurrency_test.go
+++ b/concurrency_test.go
@@ -1,0 +1,57 @@
+package gig
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// TestConcurrentWriteHammer fires 8 goroutines x 50 mixed Create/UpdateStatus
+// operations at a single store and asserts zero "database is locked" errors.
+// This exercises finding #1: without DSN _pragma busy_timeout + SetMaxOpenConns(1),
+// pooled connections default to busy_timeout=0 and fail instantly under contention.
+func TestConcurrentWriteHammer(t *testing.T) {
+	store, _ := tempDB(t)
+
+	const workers = 8
+	const ops = 50
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, workers*ops)
+
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < ops; i++ {
+				task, err := store.Create(CreateParams{
+					Title: fmt.Sprintf("w%d-task%d", w, i),
+				})
+				if err != nil {
+					errCh <- fmt.Errorf("create: %w", err)
+					continue
+				}
+				if err := store.UpdateStatus(task.ID, StatusInProgress, "hammer"); err != nil {
+					errCh <- fmt.Errorf("update: %w", err)
+				}
+			}
+		}(w)
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	var locked, other int
+	for err := range errCh {
+		if strings.Contains(err.Error(), "database is locked") {
+			locked++
+		} else {
+			other++
+			t.Errorf("unexpected error: %v", err)
+		}
+	}
+	if locked > 0 {
+		t.Errorf("got %d 'database is locked' errors — busy_timeout/SetMaxOpenConns not applied", locked)
+	}
+}

--- a/event.go
+++ b/event.go
@@ -6,10 +6,13 @@ import (
 )
 
 // Events returns all events for a specific task, oldest first.
+//
+// Ordered by (timestamp, id) so events sharing a timestamp — RFC3339 has only
+// second precision — come back in insertion order rather than an unspecified one.
 func (s *Store) Events(taskID string) ([]*Event, error) {
 	rows, err := s.db.Query(
 		`SELECT id, task_id, event_type, actor, field, old_value, new_value, timestamp
-		 FROM events WHERE task_id = ? ORDER BY timestamp ASC`, taskID,
+		 FROM events WHERE task_id = ? ORDER BY timestamp ASC, id ASC`, taskID,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("query events: %w", err)
@@ -19,15 +22,42 @@ func (s *Store) Events(taskID string) ([]*Event, error) {
 	return s.scanEvents(rows)
 }
 
-// EventsSince returns all events after the given timestamp.
+// EventsSince returns all events after the given timestamp, oldest first.
+//
+// Because timestamps have only second precision, a consumer polling with a time
+// cursor can miss or duplicate events sharing the boundary second. Prefer
+// EventsAfterID for a reliable resume cursor. Ordered by (timestamp, id).
 func (s *Store) EventsSince(since time.Time) ([]*Event, error) {
 	rows, err := s.db.Query(
 		`SELECT id, task_id, event_type, actor, field, old_value, new_value, timestamp
-		 FROM events WHERE timestamp > ? ORDER BY timestamp ASC`,
+		 FROM events WHERE timestamp > ? ORDER BY timestamp ASC, id ASC`,
 		since.Format(timeFormat),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("query events since: %w", err)
+	}
+	defer rows.Close()
+
+	return s.scanEvents(rows)
+}
+
+// EventsAfterID returns up to limit events with id > afterID, ordered by id.
+// The id is a monotonically increasing integer suitable as a resume cursor:
+// persist the last id you processed and pass it back to continue exactly where
+// you left off, with no missed or duplicated events (unlike a timestamp cursor).
+// A limit <= 0 means no limit. Pass afterID = 0 to start from the beginning.
+func (s *Store) EventsAfterID(afterID int64, limit int) ([]*Event, error) {
+	query := `SELECT id, task_id, event_type, actor, field, old_value, new_value, timestamp
+		 FROM events WHERE id > ? ORDER BY id ASC`
+	args := []any{afterID}
+	if limit > 0 {
+		query += " LIMIT ?"
+		args = append(args, limit)
+	}
+
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query events after id: %w", err)
 	}
 	defer rows.Close()
 

--- a/store.go
+++ b/store.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sync"
@@ -15,9 +16,13 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-const defaultHashLength = 4
+// defaultHashLength is the hash-portion length of generated IDs. 6 hex chars =
+// 16.7M values (e.g. "gig-a3f8c1"), keeping the birthday-bound collision
+// probability low into the tens of thousands of tasks. Existing shorter IDs
+// stay valid — length only affects newly generated IDs.
+const defaultHashLength = 6
 
-// GenerateID produces a short, prefix-based ID like "gig-a3f8".
+// GenerateID produces a short, prefix-based ID like "gig-a3f8c1".
 // The hash is derived from a UUID + current timestamp to ensure uniqueness.
 func GenerateID(prefix string, hashLen int) string {
 	if prefix == "" {
@@ -57,7 +62,7 @@ func WithPrefix(p string) Option {
 	}
 }
 
-// WithHashLength sets the hash portion length of generated IDs (3-8, default: 4).
+// WithHashLength sets the hash portion length of generated IDs (3-8, default: 6).
 func WithHashLength(n int) Option {
 	return func(s *Store) {
 		if n >= 3 && n <= 8 {
@@ -75,6 +80,17 @@ func WithConfig(c *Config) Option {
 
 // Open creates or opens a gig database at the given path.
 // It runs pending migrations and enables WAL mode and foreign keys.
+//
+// PRAGMAs are applied via the DSN's _pragma query params so they bind to
+// *every* pooled connection (not just whichever one ran a one-off PRAGMA
+// exec). SetMaxOpenConns(1) additionally serializes Go-side access, matching
+// SQLite's single-writer reality and making multi-statement sequences
+// race-free within a process. busy_timeout(5000) covers cross-process
+// contention (multi-agent use).
+//
+// Note: the "file:" DSN treats '?' and '#' in dbPath as query/fragment
+// delimiters. A path containing those characters will be misparsed; escaping
+// them breaks '/' handling, so such paths are simply unsupported.
 func Open(dbPath string, opts ...Option) (*Store, error) {
 	// Ensure parent directory exists.
 	dir := filepath.Dir(dbPath)
@@ -82,28 +98,16 @@ func Open(dbPath string, opts ...Option) (*Store, error) {
 		return nil, fmt.Errorf("create db directory: %w", err)
 	}
 
-	db, err := sql.Open("sqlite", dbPath)
+	// modernc.org/sqlite applies _pragma query params to every new connection.
+	dsn := "file:" + dbPath + "?_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=foreign_keys(1)"
+	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("open database: %w", err)
 	}
 
-	// Enable WAL mode for better concurrent read performance.
-	if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
-		db.Close()
-		return nil, fmt.Errorf("enable WAL: %w", err)
-	}
-
-	// Wait up to 5s when the database is locked by another process (multi-agent).
-	if _, err := db.Exec("PRAGMA busy_timeout=5000"); err != nil {
-		db.Close()
-		return nil, fmt.Errorf("set busy timeout: %w", err)
-	}
-
-	// Enable foreign key enforcement.
-	if _, err := db.Exec("PRAGMA foreign_keys=ON"); err != nil {
-		db.Close()
-		return nil, fmt.Errorf("enable foreign keys: %w", err)
-	}
+	// Serialize Go-side access: SQLite is single-writer, and a single conn
+	// makes COUNT+INSERT and other multi-statement sequences race-free in-process.
+	db.SetMaxOpenConns(1)
 
 	// Run migrations.
 	if err := migrate.Run(db); err != nil {
@@ -114,7 +118,7 @@ func Open(dbPath string, opts ...Option) (*Store, error) {
 	s := &Store{
 		db:        db,
 		prefix:    "gig",
-		hashLen:   4,
+		hashLen:   defaultHashLength,
 		listeners: make(map[EventType][]func(Event)),
 	}
 
@@ -146,6 +150,11 @@ func (s *Store) newID() string {
 }
 
 // emit fires all registered listeners for the given event type.
+//
+// Listeners run synchronously on the writing goroutine — keep them fast; a slow
+// callback blocks the mutation that triggered it. Emission is in-process only:
+// other processes writing to the same database file do NOT trigger these
+// listeners (use EventsAfterID as a cross-process sweep instead).
 func (s *Store) emit(e Event) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -156,6 +165,9 @@ func (s *Store) emit(e Event) {
 }
 
 // On registers a callback for the given event type.
+//
+// Callbacks run synchronously on the writing goroutine and in-process only —
+// see emit. Keep them fast; offload slow work to your own goroutine/queue.
 func (s *Store) On(eventType EventType, fn func(Event)) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -169,14 +181,25 @@ func (s *Store) Off(eventType EventType) {
 	delete(s.listeners, eventType)
 }
 
+const insertEventSQL = `INSERT INTO events (task_id, event_type, actor, field, old_value, new_value, timestamp)
+	 VALUES (?, ?, ?, ?, ?, ?, ?)`
+
 // recordEvent inserts an event into the events table and emits it to listeners.
-func (s *Store) recordEvent(taskID string, eventType EventType, actor, field, oldVal, newVal string) {
+//
+// The INSERT error is returned rather than discarded (finding #3: a silently
+// dropped SQLITE_BUSY meant an audit record vanished with no trace). Callers on
+// the non-transactional emit path may choose log-and-continue, but the failure
+// is also surfaced here via slog so it is never invisible.
+func (s *Store) recordEvent(taskID string, eventType EventType, actor, field, oldVal, newVal string) error {
 	now := timeNowUTC()
-	_, _ = s.db.Exec(
-		`INSERT INTO events (task_id, event_type, actor, field, old_value, new_value, timestamp)
-		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+	_, err := s.db.Exec(insertEventSQL,
 		taskID, string(eventType), actor, field, oldVal, newVal, now.Format(timeFormat),
 	)
+	if err != nil {
+		slog.Warn("gig: failed to record event",
+			"task_id", taskID, "event_type", string(eventType), "err", err)
+		return fmt.Errorf("record event: %w", err)
+	}
 
 	s.emit(Event{
 		TaskID:    taskID,
@@ -187,4 +210,29 @@ func (s *Store) recordEvent(taskID string, eventType EventType, actor, field, ol
 		NewValue:  newVal,
 		Timestamp: now,
 	})
+	return nil
+}
+
+// recordEventTx inserts an event using the given transaction. Unlike recordEvent
+// it does NOT emit — the caller must emit only after the transaction commits, so
+// listeners never observe events for a mutation that later rolled back. It
+// returns an Event describing what was written so the caller can emit it.
+func (s *Store) recordEventTx(tx *sql.Tx, taskID string, eventType EventType, actor, field, oldVal, newVal string) (Event, error) {
+	now := timeNowUTC()
+	_, err := tx.Exec(insertEventSQL,
+		taskID, string(eventType), actor, field, oldVal, newVal, now.Format(timeFormat),
+	)
+	e := Event{
+		TaskID:    taskID,
+		Type:      eventType,
+		Actor:     actor,
+		Field:     field,
+		OldValue:  oldVal,
+		NewValue:  newVal,
+		Timestamp: now,
+	}
+	if err != nil {
+		return e, fmt.Errorf("record event: %w", err)
+	}
+	return e, nil
 }

--- a/task.go
+++ b/task.go
@@ -2,9 +2,16 @@ package gig
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
+	"time"
 )
+
+// ErrAlreadyClaimed is returned by Claim when the task is already held by a
+// different assignee (or is in a terminal state). Callers can branch on it with
+// errors.Is to distinguish a lost claim race from other failures.
+var ErrAlreadyClaimed = errors.New("task already claimed")
 
 // Create inserts a new task and returns it.
 func (s *Store) Create(p CreateParams) (*Task, error) {
@@ -28,20 +35,7 @@ func (s *Store) Create(p CreateParams) (*Task, error) {
 
 	now := timeNowUTC()
 
-	// Generate ID: subtasks get ladder notation (parent.1, parent.2, ...)
-	var id string
-	if p.ParentID != "" {
-		var count int
-		if err := s.db.QueryRow("SELECT COUNT(*) FROM tasks WHERE parent_id = ?", p.ParentID).Scan(&count); err != nil {
-			return nil, fmt.Errorf("count children: %w", err)
-		}
-		id = fmt.Sprintf("%s.%d", p.ParentID, count+1)
-	} else {
-		id = s.newID()
-	}
-
 	task := &Task{
-		ID:          id,
 		ParentID:    p.ParentID,
 		Title:       p.Title,
 		Description: p.Description,
@@ -61,7 +55,57 @@ func (s *Store) Create(p CreateParams) (*Task, error) {
 
 	parentID := sql.NullString{String: p.ParentID, Valid: p.ParentID != ""}
 
-	_, err := s.db.Exec(
+	// Insert + audit event live in one transaction so a crash between them can't
+	// leave a task with no creation record. For subtasks the child-count read
+	// must share that transaction too, otherwise two concurrent creations mint
+	// the same "parent.N" ladder ID.
+	//
+	// On a UNIQUE-id collision we regenerate and retry (root: fresh random ID;
+	// subtask: bump the ladder offset), bounded by maxCreateRetries.
+	const maxCreateRetries = 5
+	for attempt := 0; ; attempt++ {
+		id, event, err := s.tryCreate(p, task, parentID, now, attempt)
+		if err == nil {
+			task.ID = id
+			s.emit(event)
+			return task, nil
+		}
+		if !isUniqueTaskIDViolation(err) {
+			return nil, err
+		}
+		if attempt >= maxCreateRetries {
+			if p.ParentID != "" {
+				return nil, fmt.Errorf("subtask id space exhausted for parent %s after %d attempts", p.ParentID, attempt+1)
+			}
+			return nil, fmt.Errorf("id space exhausted after %d attempts — raise WithHashLength", attempt+1)
+		}
+	}
+}
+
+// tryCreate performs one attempt of the Create transaction: determine the ID
+// (ladder for subtasks, random for roots), INSERT the task, and record the
+// creation event — all within a single transaction. The returned Event must be
+// emitted by the caller only after this returns nil (i.e. after commit).
+// `attempt` offsets the ladder counter so ladder-collision retries advance.
+func (s *Store) tryCreate(p CreateParams, task *Task, parentID sql.NullString, now time.Time, attempt int) (string, Event, error) {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return "", Event{}, fmt.Errorf("begin create: %w", err)
+	}
+	defer tx.Rollback() // no-op after a successful Commit
+
+	var id string
+	if p.ParentID != "" {
+		var count int
+		if err := tx.QueryRow("SELECT COUNT(*) FROM tasks WHERE parent_id = ?", p.ParentID).Scan(&count); err != nil {
+			return "", Event{}, fmt.Errorf("count children: %w", err)
+		}
+		id = fmt.Sprintf("%s.%d", p.ParentID, count+1+attempt)
+	} else {
+		id = s.newID()
+	}
+
+	_, err = tx.Exec(
 		`INSERT INTO tasks (id, parent_id, title, description, status, priority, assignee,
 		  task_type, labels, notes, estimate, due_at, created_at, updated_at, created_by, metadata)
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -71,11 +115,29 @@ func (s *Store) Create(p CreateParams) (*Task, error) {
 		p.CreatedBy, p.Metadata,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("insert task: %w", err)
+		// Return the raw error so the caller can detect a UNIQUE-id collision.
+		if isUniqueTaskIDViolation(err) {
+			return "", Event{}, err
+		}
+		return "", Event{}, fmt.Errorf("insert task: %w", err)
 	}
 
-	s.recordEvent(id, EventCreated, p.CreatedBy, "", "", p.Title)
-	return task, nil
+	event, err := s.recordEventTx(tx, id, EventCreated, p.CreatedBy, "", "", p.Title)
+	if err != nil {
+		return "", Event{}, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return "", Event{}, fmt.Errorf("commit create: %w", err)
+	}
+	return id, event, nil
+}
+
+// isUniqueTaskIDViolation reports whether err is a SQLite UNIQUE-constraint
+// failure on tasks.id. modernc.org/sqlite exposes no typed error for this, so
+// we match on the message text (stable across the driver's error formatting).
+func isUniqueTaskIDViolation(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "UNIQUE constraint failed: tasks.id")
 }
 
 // Get retrieves a single task by ID.
@@ -119,6 +181,13 @@ func (s *Store) validateTaskExists(taskID string) error {
 	return nil
 }
 
+// eventSpec describes an audit event to record inside the Update transaction,
+// once the field diffs have been collected and the mutation is about to happen.
+type eventSpec struct {
+	eventType             EventType
+	field, oldVal, newVal string
+}
+
 // Update modifies fields of an existing task.
 func (s *Store) Update(id string, p UpdateParams, actor string) (*Task, error) {
 	task, err := s.Get(id)
@@ -128,34 +197,35 @@ func (s *Store) Update(id string, p UpdateParams, actor string) (*Task, error) {
 
 	sets := []string{}
 	args := []any{}
+	var specs []eventSpec
 
 	if p.Title != nil && *p.Title != task.Title {
-		s.recordEvent(id, EventUpdated, actor, "title", task.Title, *p.Title)
+		specs = append(specs, eventSpec{EventUpdated, "title", task.Title, *p.Title})
 		sets = append(sets, "title = ?")
 		args = append(args, *p.Title)
 	}
 	if p.Description != nil && *p.Description != task.Description {
-		s.recordEvent(id, EventUpdated, actor, "description", task.Description, *p.Description)
+		specs = append(specs, eventSpec{EventUpdated, "description", task.Description, *p.Description})
 		sets = append(sets, "description = ?")
 		args = append(args, *p.Description)
 	}
 	if p.Priority != nil && *p.Priority != task.Priority {
-		s.recordEvent(id, EventUpdated, actor, "priority", fmt.Sprintf("%d", task.Priority), fmt.Sprintf("%d", *p.Priority))
+		specs = append(specs, eventSpec{EventUpdated, "priority", fmt.Sprintf("%d", task.Priority), fmt.Sprintf("%d", *p.Priority)})
 		sets = append(sets, "priority = ?")
 		args = append(args, int(*p.Priority))
 	}
 	if p.Assignee != nil && *p.Assignee != task.Assignee {
-		s.recordEvent(id, EventAssigned, actor, "assignee", task.Assignee, *p.Assignee)
+		specs = append(specs, eventSpec{EventAssigned, "assignee", task.Assignee, *p.Assignee})
 		sets = append(sets, "assignee = ?")
 		args = append(args, *p.Assignee)
 	}
 	if p.Labels != nil {
-		s.recordEvent(id, EventUpdated, actor, "labels", labelsToJSON(task.Labels), labelsToJSON(*p.Labels))
+		specs = append(specs, eventSpec{EventUpdated, "labels", labelsToJSON(task.Labels), labelsToJSON(*p.Labels)})
 		sets = append(sets, "labels = ?")
 		args = append(args, labelsToJSON(*p.Labels))
 	}
 	if p.Orphan && task.ParentID != "" {
-		s.recordEvent(id, EventUpdated, actor, "parent_id", task.ParentID, "")
+		specs = append(specs, eventSpec{EventUpdated, "parent_id", task.ParentID, ""})
 		sets = append(sets, "parent_id = NULL")
 	} else if p.ParentID != nil && *p.ParentID != task.ParentID {
 		if *p.ParentID == "" {
@@ -167,17 +237,17 @@ func (s *Store) Update(id string, p UpdateParams, actor string) (*Task, error) {
 		if err := s.validateTaskExists(*p.ParentID); err != nil {
 			return nil, err
 		}
-		s.recordEvent(id, EventUpdated, actor, "parent_id", task.ParentID, *p.ParentID)
+		specs = append(specs, eventSpec{EventUpdated, "parent_id", task.ParentID, *p.ParentID})
 		sets = append(sets, "parent_id = ?")
 		args = append(args, *p.ParentID)
 	}
 	if p.Notes != nil && *p.Notes != task.Notes {
-		s.recordEvent(id, EventUpdated, actor, "notes", task.Notes, *p.Notes)
+		specs = append(specs, eventSpec{EventUpdated, "notes", task.Notes, *p.Notes})
 		sets = append(sets, "notes = ?")
 		args = append(args, *p.Notes)
 	}
 	if p.Estimate != nil && *p.Estimate != task.Estimate {
-		s.recordEvent(id, EventUpdated, actor, "estimate", fmt.Sprintf("%d", task.Estimate), fmt.Sprintf("%d", *p.Estimate))
+		specs = append(specs, eventSpec{EventUpdated, "estimate", fmt.Sprintf("%d", task.Estimate), fmt.Sprintf("%d", *p.Estimate)})
 		sets = append(sets, "estimate = ?")
 		args = append(args, *p.Estimate)
 	}
@@ -198,9 +268,31 @@ func (s *Store) Update(id string, p UpdateParams, actor string) (*Task, error) {
 	args = append(args, timeNowUTC().Format(timeFormat))
 	args = append(args, id)
 
+	tx, err := s.db.Begin()
+	if err != nil {
+		return nil, fmt.Errorf("begin update: %w", err)
+	}
+	defer tx.Rollback()
+
 	query := fmt.Sprintf("UPDATE tasks SET %s WHERE id = ?", strings.Join(sets, ", "))
-	if _, err := s.db.Exec(query, args...); err != nil {
+	if _, err := tx.Exec(query, args...); err != nil {
 		return nil, fmt.Errorf("update task: %w", err)
+	}
+
+	events := make([]Event, 0, len(specs))
+	for _, sp := range specs {
+		e, err := s.recordEventTx(tx, id, sp.eventType, actor, sp.field, sp.oldVal, sp.newVal)
+		if err != nil {
+			return nil, err
+		}
+		events = append(events, e)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit update: %w", err)
+	}
+	for _, e := range events {
+		s.emit(e)
 	}
 
 	return s.Get(id)
@@ -224,15 +316,29 @@ func (s *Store) UpdateStatus(id string, status Status, actor string) error {
 	}
 
 	now := timeNowUTC()
-	_, err = s.db.Exec(
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin update status: %w", err)
+	}
+	defer tx.Rollback()
+
+	if _, err = tx.Exec(
 		"UPDATE tasks SET status = ?, updated_at = ? WHERE id = ?",
 		string(status), now.Format(timeFormat), id,
-	)
-	if err != nil {
+	); err != nil {
 		return fmt.Errorf("update status: %w", err)
 	}
 
-	s.recordEvent(id, EventStatusChanged, actor, "status", string(task.Status), string(status))
+	event, err := s.recordEventTx(tx, id, EventStatusChanged, actor, "status", string(task.Status), string(status))
+	if err != nil {
+		return err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit update status: %w", err)
+	}
+	s.emit(event)
 
 	// Auto-progress parent when child becomes active.
 	if status == StatusInProgress {
@@ -264,15 +370,29 @@ func (s *Store) CloseTask(id string, reason string, actor string) error {
 	}
 
 	now := timeNowUTC()
-	_, err = s.db.Exec(
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin close task: %w", err)
+	}
+	defer tx.Rollback()
+
+	if _, err = tx.Exec(
 		"UPDATE tasks SET status = ?, closed_at = ?, close_reason = ?, updated_at = ? WHERE id = ?",
 		string(StatusClosed), now.Format(timeFormat), reason, now.Format(timeFormat), id,
-	)
-	if err != nil {
+	); err != nil {
 		return fmt.Errorf("close task: %w", err)
 	}
 
-	s.recordEvent(id, EventClosed, actor, "status", string(task.Status), string(StatusClosed))
+	event, err := s.recordEventTx(tx, id, EventClosed, actor, "status", string(task.Status), string(StatusClosed))
+	if err != nil {
+		return err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit close task: %w", err)
+	}
+	s.emit(event)
 
 	if err := s.autoUnblock(id, actor); err != nil {
 		return fmt.Errorf("auto-unblock after closing %s: %w", id, err)
@@ -292,15 +412,29 @@ func (s *Store) CancelTask(id string, reason string, actor string) error {
 	}
 
 	now := timeNowUTC()
-	_, err = s.db.Exec(
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin cancel task: %w", err)
+	}
+	defer tx.Rollback()
+
+	if _, err = tx.Exec(
 		"UPDATE tasks SET status = ?, closed_at = ?, close_reason = ?, updated_at = ? WHERE id = ?",
 		string(StatusCancelled), now.Format(timeFormat), reason, now.Format(timeFormat), id,
-	)
-	if err != nil {
+	); err != nil {
 		return fmt.Errorf("cancel task: %w", err)
 	}
 
-	s.recordEvent(id, EventStatusChanged, actor, "status", string(task.Status), string(StatusCancelled))
+	event, err := s.recordEventTx(tx, id, EventStatusChanged, actor, "status", string(task.Status), string(StatusCancelled))
+	if err != nil {
+		return err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit cancel task: %w", err)
+	}
+	s.emit(event)
 
 	if err := s.autoUnblock(id, actor); err != nil {
 		return fmt.Errorf("auto-unblock after cancelling %s: %w", id, err)
@@ -453,36 +587,96 @@ type ClaimResult struct {
 	ParentID         string // parent task ID (if progressed)
 }
 
-// Claim atomically sets assignee and status to in_progress.
+// Claim atomically sets assignee and status to in_progress using a
+// compare-and-swap: the UPDATE only fires when the task is not already claimed
+// by someone else and is not terminal. Two concurrent claimers can no longer
+// both "win" — exactly one UPDATE affects a row; the loser gets ErrAlreadyClaimed.
+//
+// Semantics:
+//   - open / blocked / deferred → claimable (matches prior behaviour: only
+//     terminal states were rejected).
+//   - in_progress by the SAME assignee → allowed (idempotent resume).
+//   - in_progress by a DIFFERENT assignee → ErrAlreadyClaimed.
+//   - closed / cancelled → ErrAlreadyClaimed (terminal).
+//
 // If the task has a parent that is open, it is auto-progressed to in_progress.
 func (s *Store) Claim(id string, assignee string) (*ClaimResult, error) {
+	// Pre-read for event old-values. With SetMaxOpenConns(1) the in-process
+	// window between this read and the CAS is closed; cross-process, the CAS
+	// itself is the guarantee.
 	task, err := s.Get(id)
 	if err != nil {
 		return nil, err
 	}
-	if task.Status.IsTerminal() {
-		return nil, fmt.Errorf("cannot claim %s task %s", task.Status, id)
-	}
 
 	now := timeNowUTC()
-	_, err = s.db.Exec(
-		"UPDATE tasks SET assignee = ?, status = ?, updated_at = ? WHERE id = ?",
-		assignee, string(StatusInProgress), now.Format(timeFormat), id,
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return nil, fmt.Errorf("begin claim: %w", err)
+	}
+	defer tx.Rollback()
+
+	// CAS: claim only when the row is not terminal and not held by a different
+	// assignee. The same-assignee carve-out allows idempotent re-claim.
+	res, err := tx.Exec(
+		`UPDATE tasks SET assignee = ?, status = ?, updated_at = ?
+		 WHERE id = ?
+		   AND status NOT IN (?, ?)
+		   AND NOT (status = ? AND assignee != ?)`,
+		assignee, string(StatusInProgress), now.Format(timeFormat),
+		id,
+		string(StatusClosed), string(StatusCancelled),
+		string(StatusInProgress), assignee,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("claim task: %w", err)
 	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return nil, fmt.Errorf("claim rows affected: %w", err)
+	}
+	if n == 0 {
+		// Distinguish a genuinely missing task from a lost claim. Read within
+		// the transaction — calling s.Get here would deadlock, since the single
+		// pooled connection (SetMaxOpenConns(1)) is held by this open tx.
+		var assignee, status string
+		gerr := tx.QueryRow("SELECT assignee, status FROM tasks WHERE id = ?", id).Scan(&assignee, &status)
+		if gerr == sql.ErrNoRows {
+			return nil, fmt.Errorf("task not found: %s", id)
+		}
+		if gerr != nil {
+			return nil, fmt.Errorf("claim lookup: %w", gerr)
+		}
+		return nil, fmt.Errorf("%w: %s held by %q (status %s)", ErrAlreadyClaimed, id, assignee, status)
+	}
 
+	var events []Event
 	if task.Assignee != assignee {
-		s.recordEvent(id, EventAssigned, assignee, "assignee", task.Assignee, assignee)
+		e, err := s.recordEventTx(tx, id, EventAssigned, assignee, "assignee", task.Assignee, assignee)
+		if err != nil {
+			return nil, err
+		}
+		events = append(events, e)
 	}
 	if task.Status != StatusInProgress {
-		s.recordEvent(id, EventStatusChanged, assignee, "status", string(task.Status), string(StatusInProgress))
+		e, err := s.recordEventTx(tx, id, EventStatusChanged, assignee, "status", string(task.Status), string(StatusInProgress))
+		if err != nil {
+			return nil, err
+		}
+		events = append(events, e)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit claim: %w", err)
+	}
+	for _, e := range events {
+		s.emit(e)
 	}
 
 	result := &ClaimResult{}
 
-	// Auto-progress parent when child becomes active.
+	// Auto-progress parent when child becomes active (its own transaction).
 	if s.autoProgressParent(task.ParentID, assignee) {
 		result.ParentProgressed = true
 		result.ParentID = task.ParentID

--- a/upgrades_test.go
+++ b/upgrades_test.go
@@ -1,0 +1,165 @@
+package gig
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// TestCreateCollisionRetry drives the ID space small (WithHashLength(3) = 4096
+// values) and creates enough tasks that the birthday bound forces collisions.
+// Every Create must still succeed — the retry loop regenerates on a UNIQUE
+// violation rather than surfacing a raw constraint error (finding #4).
+func TestCreateCollisionRetry(t *testing.T) {
+	dir := t.TempDir()
+	store, err := Open(filepath.Join(dir, "test.db"), WithPrefix("test"), WithHashLength(3))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer store.Close()
+
+	seen := make(map[string]bool)
+	for i := 0; i < 300; i++ {
+		task, err := store.Create(CreateParams{Title: fmt.Sprintf("t%d", i)})
+		if err != nil {
+			t.Fatalf("create %d failed (retry loop should have recovered): %v", i, err)
+		}
+		if seen[task.ID] {
+			t.Fatalf("duplicate ID minted: %s", task.ID)
+		}
+		seen[task.ID] = true
+	}
+}
+
+// TestSubtaskLadderRace creates many children of one parent concurrently and
+// asserts every child gets a unique ladder ID — the COUNT+INSERT now shares a
+// transaction and retries on collision (finding #4, ladder race).
+func TestSubtaskLadderRace(t *testing.T) {
+	store, _ := tempDB(t)
+	parent, _ := store.Create(CreateParams{Title: "Parent", Type: TypeEpic})
+
+	const n = 40
+	var wg sync.WaitGroup
+	ids := make(chan string, n)
+	errs := make(chan error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			child, err := store.Create(CreateParams{Title: fmt.Sprintf("c%d", i), ParentID: parent.ID})
+			if err != nil {
+				errs <- err
+				return
+			}
+			ids <- child.ID
+		}(i)
+	}
+	wg.Wait()
+	close(ids)
+	close(errs)
+
+	for err := range errs {
+		t.Errorf("child create failed: %v", err)
+	}
+	seen := make(map[string]bool)
+	count := 0
+	for id := range ids {
+		if seen[id] {
+			t.Errorf("duplicate ladder ID: %s", id)
+		}
+		seen[id] = true
+		count++
+	}
+	if count != n {
+		t.Errorf("expected %d children, got %d", n, count)
+	}
+}
+
+// TestEventRollbackOnFailedInsert drops the events table so the event INSERT
+// inside a mutation's transaction fails; the mutation itself must roll back
+// (finding #3 — write + audit are atomic).
+func TestEventRollbackOnFailedInsert(t *testing.T) {
+	store, _ := tempDB(t)
+	task, _ := store.Create(CreateParams{Title: "Task"})
+
+	if _, err := store.DB().Exec("DROP TABLE events"); err != nil {
+		t.Fatalf("drop events: %v", err)
+	}
+
+	// UpdateStatus should now fail because its event insert fails.
+	err := store.UpdateStatus(task.ID, StatusInProgress, "actor")
+	if err == nil {
+		t.Fatal("expected UpdateStatus to fail after events table dropped")
+	}
+
+	// Recreate events so we can read task state, then confirm status unchanged.
+	if _, rerr := store.DB().Exec(`CREATE TABLE events (
+		id INTEGER PRIMARY KEY AUTOINCREMENT, task_id TEXT NOT NULL, event_type TEXT NOT NULL,
+		actor TEXT DEFAULT '', field TEXT DEFAULT '', old_value TEXT DEFAULT '',
+		new_value TEXT DEFAULT '', timestamp TEXT NOT NULL)`); rerr != nil {
+		t.Fatalf("recreate events: %v", rerr)
+	}
+	got, _ := store.Get(task.ID)
+	if got.Status != StatusOpen {
+		t.Errorf("status should have rolled back to open, got %q", got.Status)
+	}
+}
+
+// TestEventsAfterID verifies the integer-cursor pagination and ordering.
+func TestEventsAfterID(t *testing.T) {
+	store, _ := tempDB(t)
+
+	// Generate a known sequence of events.
+	task, _ := store.Create(CreateParams{Title: "Task"}) // EventCreated (id 1)
+	store.UpdateStatus(task.ID, StatusInProgress, "a")    // EventStatusChanged (id 2)
+	store.UpdateStatus(task.ID, StatusBlocked, "a")       // id 3
+	store.UpdateStatus(task.ID, StatusOpen, "a")          // id 4
+
+	all, err := store.EventsAfterID(0, 0)
+	if err != nil {
+		t.Fatalf("EventsAfterID: %v", err)
+	}
+	if len(all) < 4 {
+		t.Fatalf("expected >=4 events, got %d", len(all))
+	}
+
+	// Strictly increasing ids.
+	for i := 1; i < len(all); i++ {
+		if all[i].ID <= all[i-1].ID {
+			t.Errorf("ids not strictly increasing: %d then %d", all[i-1].ID, all[i].ID)
+		}
+	}
+
+	// Pagination: limit 2 from the start, then resume from the last id.
+	page1, _ := store.EventsAfterID(0, 2)
+	if len(page1) != 2 {
+		t.Fatalf("page1 expected 2, got %d", len(page1))
+	}
+	page2, _ := store.EventsAfterID(page1[1].ID, 2)
+	if len(page2) < 1 {
+		t.Fatalf("page2 expected >=1, got %d", len(page2))
+	}
+	if page2[0].ID <= page1[1].ID {
+		t.Errorf("resume cursor leaked/duplicated: page2 starts at %d, cursor was %d", page2[0].ID, page1[1].ID)
+	}
+
+	// afterID past the end returns empty.
+	last := all[len(all)-1].ID
+	empty, _ := store.EventsAfterID(last, 10)
+	if len(empty) != 0 {
+		t.Errorf("expected no events after last id, got %d", len(empty))
+	}
+}
+
+// TestDefaultHashLength confirms the default ID length bumped 4 -> 6.
+func TestDefaultHashLength(t *testing.T) {
+	store, _ := tempDB(t)
+	task, _ := store.Create(CreateParams{Title: "Task"})
+	// prefix "test" + "-" + 6 hex chars.
+	parts := strings.SplitN(task.ID, "-", 2)
+	if len(parts) != 2 || len(parts[1]) != 6 {
+		t.Errorf("expected 6-char hash, got ID %q", task.ID)
+	}
+}


### PR DESCRIPTION
Executes `PLAN-Gig-Upgrades` — hardens gig for the multi-client/worker model. Six findings, all verified in v0.6.2 source, fixed in priority order. Deliverable is this PR only; tagging v0.7.0 and the JEFF `go.mod` bump are handled post-merge by the orchestrator.

## Changes

1. **DSN PRAGMAs (`store.go`)** — `busy_timeout(5000)`/`journal_mode(WAL)`/`foreign_keys(1)` now set via the DSN's `_pragma` query params so they bind to *every* pooled connection, plus `SetMaxOpenConns(1)` to serialize in-process access. Previously the one-off `db.Exec("PRAGMA …")` calls bound to a single pooled connection, leaving others with `busy_timeout=0` and FKs off.
2. **CAS `Claim` + `ErrAlreadyClaimed` (`task.go`)** — conditional `UPDATE` so two concurrent claimers can't both win. Same-assignee re-claim allowed (idempotent resume); different-assignee or terminal → `ErrAlreadyClaimed` (check with `errors.Is`). `open`/`blocked`/`deferred` stay claimable.
3. **Durable transactional events** — `Create`, `Update`, `UpdateStatus`, `CloseTask`, `CancelTask`, `Claim` wrap mutation + audit event in one transaction, emitting to listeners only after commit. `recordEvent` returns its error and `slog.Warn`s instead of silently dropping it.
4. **ID generation** — default hash length 4 → 6 (65K → 16.7M space; existing IDs stay valid). `Create` retries on a `UNIQUE constraint` collision (root: regenerate; subtask: bump ladder offset) then errors clearly if exhausted. Subtask ladder `COUNT`+`INSERT` now share the `Create` transaction, killing the duplicate-ladder-ID race.
5. **`EventsAfterID(afterID, limit)`** — integer-PK resume cursor with no missed/duplicated events. `Events`/`EventsSince` now order by `(timestamp, id)` for deterministic same-second batches.
6. **Docs** — `On`/`emit` doc comments note synchronous, in-process-only semantics; new `CHANGELOG.md`.

Also: added `-race` + a `go vet` step to CI (test **and** release workflows), and fixed a **latent nested-query-during-iteration deadlock in `ListCheckpoints`** that `SetMaxOpenConns(1)` promoted from harmless to fatal.

## Tests

New: concurrent-claim (one `ErrAlreadyClaimed`), same-assignee re-claim, different-assignee reject, terminal reject, blocked/deferred claimable; 8×50 concurrent-write hammer (zero "database is locked"); `Create` collision-retry (`WithHashLength(3)` brute-force); subtask ladder race; event-rollback-on-failed-insert; `EventsAfterID` pagination + ordering; default-hash-length.

## Acceptance

- `go build ./... && go vet ./... && go test ./... -race` — green (unit + e2e).
- `grep -n "PRAGMA" store.go` → doc comments only, no executable PRAGMA.
- `grep -n "_, _ = s.db.Exec" store.go` → gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)